### PR TITLE
Change dbdbserver-dbname-schema separator from "." to "#"

### DIFF
--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/DeletionHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/DeletionHarvester.java
@@ -53,9 +53,9 @@ public class DeletionHarvester extends Harvester implements Runnable
      * Constructor.
      *
      * @param src
-     *            source server.database.schema
+     *            source server#database#schema
      * @param dest
-     *            destination server.database.schema
+     *            destination server#database#schema
      * @param entityClass
      *            the class specifying what should be deleted
      * @param batchSize

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -113,10 +113,10 @@ public class Main
                 usage();
                 System.exit(1);
             }
-            String[] destDS = destination.split("[.]");
+            String[] destDS = destination.split("[#]");
             if (destDS.length != 3)
             {
-                log.warn("malformed --destination value, found " + destination + " expected: server.database.schema");
+                log.warn("malformed --destination value, found " + destination + " expected: server#database#schema");
                 usage();
                 System.exit(1);
             }
@@ -130,7 +130,7 @@ public class Main
             boolean nosrv = (resourceID == null || resourceID.trim().length() == 0);
             if (nosrc && nosrv )
             {
-                log.warn("missing required argument: --source=<server.database.schema> | --resourceID=<identifier>");
+                log.warn("missing required argument: --source=<server#database#schema> | --resourceID=<identifier>");
                 usage();
                 System.exit(1);
             }
@@ -160,10 +160,10 @@ public class Main
             }
             else
             {
-                String[] srcDS = source.split("[.]");
+                String[] srcDS = source.split("[#]");
                 if (srcDS.length != 3)
                 {
-                    log.warn("malformed --source value, found " + source + " expected: server.database.schema");
+                    log.warn("malformed --source value, found " + source + " expected: server#database#schema");
                     usage();
                     System.exit(1);
                 }
@@ -307,9 +307,9 @@ public class Main
         StringBuilder sb = new StringBuilder();
         sb.append("\n\nusage: caom2harvester [-v|--verbose|-d|--debug] [-h|--help] ...");
         sb.append("\n         --collection=<name> : name of collection to retrieve> (e.g. IRIS)");
-        sb.append("\n         --destination=<server.database.schema> : persist output directly to a databsee server");
+        sb.append("\n         --destination=<server#database#schema> : persist output directly to a databsee server");
         
-        sb.append("\n\nSource selection: --resourceID=<URI> [--threads=<num threads>] | --source=<server.database.schema>");
+        sb.append("\n\nSource selection: --resourceID=<URI> [--threads=<num threads>] | --source=<server#database#schema>");
         sb.append("\n         --resourceID : harvest from a caom2 repository service (e.g. ivo://cadc.nrc.ca/caom2repo)");
         sb.append("\n         --threads : number  of threads used to read observation documents (default: 1)");
         sb.append("\n         --source : harvest directly from a database server");

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ReadAccessHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ReadAccessHarvester.java
@@ -42,9 +42,9 @@ public class ReadAccessHarvester extends Harvester
      * @param entityClass
      *            the type of entity to harvest
      * @param src
-     *            source server.database.schema
+     *            source server#database#schema
      * @param dest
-     *            destination server.database.schema
+     *            destination server#database#schema
      * @param batchSize
      *            ignored, always full list
      * @param full


### PR DESCRIPTION
This allows the use of dotted DB server names in caom2harvester origin/destination arguments.