### PR TITLE
Remove hardcoded schema name from Postgres DB initialisation.

### DIFF
--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.8'
+version = '2.3.7'
 
 mainClassName = 'ca.nrc.cadc.caom2.harvester.Main'
 
@@ -28,7 +28,7 @@ dependencies {
     compile 'org.opencadc:cadc-util:[1.0,)'
     compile 'org.opencadc:caom2:[2.3.4,)'
     compile 'org.opencadc:caom2-compute:[2.3.3,)'
-    compile 'org.opencadc:caom2persistence:[2.3.8,)'
+    compile 'org.opencadc:caom2persistence:[2.3.7,)'
     compile 'org.opencadc:cadc-util:[1.0.14,)'
     compile 'org.opencadc:caom2-repo:[1.0,)'
     compile 'org.opencadc:caom2-persist:[2.3.1,)'

--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.7'
+version = '2.3.8'
 
 mainClassName = 'ca.nrc.cadc.caom2.harvester.Main'
 
@@ -28,7 +28,7 @@ dependencies {
     compile 'org.opencadc:cadc-util:[1.0,)'
     compile 'org.opencadc:caom2:[2.3.4,)'
     compile 'org.opencadc:caom2-compute:[2.3.3,)'
-    compile 'org.opencadc:caom2persistence:[2.3.7,)'
+    compile 'org.opencadc:caom2persistence:[2.3.8,)'
     compile 'org.opencadc:cadc-util:[1.0.14,)'
     compile 'org.opencadc:caom2-repo:[1.0,)'
     compile 'org.opencadc:caom2-persist:[2.3.1,)'

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
@@ -418,7 +418,9 @@ public class ObservationHarvester extends Harvester {
                             // temporary validation hack to avoid tickmarks
                             // in
                             // the keywords columns
-                            CaomValidator.validateKeywords(o);
+                            //TODO Raul Gutierrez: I comment it to solve a compilation error (CaomValidator.validateKeywords() is a
+                            //  private method)
+                            //CaomValidator.validateKeywords(o);
 
                             if (computePlaneMetadata) {
                                 log.debug("computePlaneMetadata: " + o.getObservationID());

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.7'
+version = '2.3.8'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/version/InitDatabase.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/version/InitDatabase.java
@@ -168,7 +168,7 @@ public class InitDatabase {
             // execute SQL
             for (String fname : ddls) {
                 log.info("process file: " + fname);
-                List<String> statements = parseDDL(fname);
+                List<String> statements = parseDDL(fname, schema);
                 for (String sql : statements) {
                     if (upgrade) {
                         log.info("execute:\n" + sql);
@@ -211,9 +211,8 @@ public class InitDatabase {
             log.debug("doInit: " + MODEL_NAME + " " + prevVersion + " to " + MODEL_VERSION + " " + dt + "ms");
         }
     }
-
-    static List<String> parseDDL(String fname)
-            throws IOException {
+    
+    static List<String> parseDDL(String fname, String schema) throws IOException {
         List<String> ret = new ArrayList<>();
 
         // find file
@@ -240,6 +239,9 @@ public class InitDatabase {
                     sb.append(line).append(" ");
                     if (eos) {
                         String st = sb.toString();
+                        
+                        st = st.replaceAll("<schema>", schema);
+                        
                         log.debug("statement: " + st);
                         ret.add(st);
                         sb = new StringBuilder();

--- a/caom2persistence/src/main/resources/postgresql/caom2.Artifact.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.Artifact.sql
@@ -1,5 +1,5 @@
 
-create table caom2.Artifact
+create table <schema>.Artifact
 (
     uri varchar(1024) not null,
     productType varchar(64) not null,
@@ -14,7 +14,7 @@ create table caom2.Artifact
 -- internal
     metaRelease timestamp,
     obsID uuid not null,
-    planeID uuid not null references caom2.Plane (planeID),
+    planeID uuid not null references <schema>.Plane (planeID),
     artifactID uuid not null primary key,
     lastModified timestamp not null,
     maxLastModified timestamp not null,
@@ -25,9 +25,9 @@ create table caom2.Artifact
 ;
 
 -- this is for Plane join Artifact
-create index i_planeID on caom2.Artifact (planeID)
+create index i_planeID on <schema>.Artifact (planeID)
 ;
 
 -- tag the clustering index
-cluster i_planeID on caom2.Artifact
+cluster i_planeID on <schema>.Artifact
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.Chunk.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.Chunk.sql
@@ -1,5 +1,5 @@
 
-create table caom2.Chunk
+create table <schema>.Chunk
 (
     productType varchar(64),
     naxis integer,
@@ -125,7 +125,7 @@ create table caom2.Chunk
     obsID uuid not null,
     planeID uuid not null,
     artifactID uuid not null,
-    partID uuid not null references caom2.Part (partID),
+    partID uuid not null references <schema>.Part (partID),
     chunkID uuid not null primary key,
     lastModified timestamp not null,
     maxLastModified timestamp not null,
@@ -136,12 +136,12 @@ create table caom2.Chunk
 ;
 
 -- this is for Part join Chunk
-create index i_partID on caom2.Chunk (partID)
+create index i_partID on <schema>.Chunk (partID)
 ;
 
-cluster i_partID on caom2.Chunk
+cluster i_partID on <schema>.Chunk
 ;
 
 -- this is for asset updates
-create index ic_planeID on caom2.Chunk (planeID)
+create index ic_planeID on <schema>.Chunk (planeID)
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.HarvestSkip.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.HarvestSkip.sql
@@ -1,5 +1,5 @@
 
-create table caom2.HarvestSkip
+create table <schema>.HarvestSkip
 (
     source          varchar(256) not null,
     cname           varchar(256)  not null,
@@ -12,6 +12,6 @@ create table caom2.HarvestSkip
 ;
 
 create unique index HarvestSkip_i1
-    on caom2.HarvestSkip ( source,cname,skipID )
+    on <schema>.HarvestSkip ( source,cname,skipID )
 ;
 

--- a/caom2persistence/src/main/resources/postgresql/caom2.HarvestSkipURI.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.HarvestSkipURI.sql
@@ -1,5 +1,5 @@
 
-create table caom2.HarvestSkipURI
+create table <schema>.HarvestSkipURI
 (
     source          varchar(256) not null,
     cname           varchar(256) not null,
@@ -12,6 +12,6 @@ create table caom2.HarvestSkipURI
 ;
 
 create unique index HarvestSkipURI_i1
-    on caom2.HarvestSkipURI ( source,cname,skipID )
+    on <schema>.HarvestSkipURI ( source,cname,skipID )
 ;
 

--- a/caom2persistence/src/main/resources/postgresql/caom2.HarvestState.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.HarvestState.sql
@@ -1,5 +1,5 @@
 
-create table caom2.HarvestState
+create table <schema>.HarvestState
 (
     source          varchar(256) not null,
     cname           varchar(256)  not null,
@@ -12,5 +12,5 @@ create table caom2.HarvestState
 ;
 
 create unique index HarvestState_i1
-    on caom2.HarvestState ( source,cname )
+    on <schema>.HarvestState ( source,cname )
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.ModelVersion.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.ModelVersion.sql
@@ -1,5 +1,5 @@
 
-create table caom2.ModelVersion
+create table <schema>.ModelVersion
 (
     model varchar(16) not null primary key,
     version varchar(16) not null,

--- a/caom2persistence/src/main/resources/postgresql/caom2.ObsCore-x.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.ObsCore-x.sql
@@ -1,5 +1,5 @@
 
-create or replace view caom2.ObsFile
+create or replace view <schema>.ObsFile
 (
     uri,
     content_type,
@@ -28,10 +28,10 @@ AS SELECT
 
     a.planeID,
     a.metaRelease, a.metaReadAccessGroups
-FROM caom2.Artifact AS a
+FROM <schema>.Artifact AS a
 ;
 
-create or replace view caom2.ObsPart
+create or replace view <schema>.ObsPart
 (
     name,
     naxis,
@@ -145,5 +145,5 @@ AS SELECT
 
     p.planeID,
     p.metaRelease, p.metaReadAccessGroups
-FROM caom2.Part AS p JOIN caom2.Chunk AS c ON p.partID = c.partID
+FROM <schema>.Part AS p JOIN <schema>.Chunk AS c ON p.partID = c.partID
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.ObsCore.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.ObsCore.sql
@@ -1,5 +1,5 @@
 
-create or replace view caom2.ObsCore
+create or replace view <schema>.ObsCore
 (
     dataproduct_type,
     calib_level,
@@ -117,7 +117,7 @@ AS SELECT
     p.planeID,
     p.metaRelease, p.metaReadAccessGroups
 
-FROM caom2.Observation o JOIN caom2.Plane p ON o.obsID=p.obsID
+FROM <schema>.Observation o JOIN <schema>.Plane p ON o.obsID=p.obsID
 WHERE o.intent = 'science' 
   AND p.calibrationLevel IS NOT NULL
   AND p.dataProductType != 'catalog'

--- a/caom2persistence/src/main/resources/postgresql/caom2.Observation.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.Observation.sql
@@ -1,5 +1,5 @@
 
-create table caom2.Observation
+create table <schema>.Observation
 (
     observationURI varchar(512) not null,
     collection varchar(64) not null,
@@ -63,27 +63,27 @@ create table caom2.Observation
 )
 ;
 
-create unique index i_observationURI on caom2.Observation (observationURI)
+create unique index i_observationURI on <schema>.Observation (observationURI)
 ;
 
-create unique index i_observationURI2 on caom2.Observation (collection, observationID)
+create unique index i_observationURI2 on <schema>.Observation (collection, observationID)
 ;
 
 -- harvesting index for recompute mode of caom2harvester
-create index i_maxLastModified on caom2.Observation (maxLastModified)
+create index i_maxLastModified on <schema>.Observation (maxLastModified)
 ;
 
 -- member join support
 -- not currently used/tested
-create table caom2.Observation_members
+create table <schema>.Observation_members
 (
-    compositeID uuid not null references caom2.Observation (obsID),
-    simpleID uuid not null references caom2.Observation (obsID)
+    compositeID uuid not null references <schema>.Observation (obsID),
+    simpleID uuid not null references <schema>.Observation (obsID)
 )
 ;
 
-create unique index i_composite2simple on caom2.Observation_members (compositeID,simpleID)
+create unique index i_composite2simple on <schema>.Observation_members (compositeID,simpleID)
 ;
 
-create unique index i_simple2composite on caom2.Observation_members (simpleID,compositeID)
+create unique index i_simple2composite on <schema>.Observation_members (simpleID,compositeID)
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.Part.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.Part.sql
@@ -1,5 +1,5 @@
 
-create table caom2.Part
+create table <schema>.Part
 (
     name varchar(1024) not null,
     productType varchar(64),
@@ -11,7 +11,7 @@ create table caom2.Part
     metaRelease timestamp,
     obsID uuid not null,
     planeID uuid not null,
-    artifactID uuid not null references caom2.Artifact (artifactID),
+    artifactID uuid not null references <schema>.Artifact (artifactID),
     partID uuid not null primary key,
     lastModified timestamp not null,
     maxLastModified timestamp not null,
@@ -22,14 +22,14 @@ create table caom2.Part
 ;
 
 -- this is for Artifact join Part
-create index i_artifactID on caom2.Part (artifactID)
+create index i_artifactID on <schema>.Part (artifactID)
 ;
 
 -- tag the clustering index
-cluster i_artifactID on caom2.Part
+cluster i_artifactID on <schema>.Part
 ;
 
 -- this is for asset updates
-create index ip_planeID on caom2.Part (planeID)
+create index ip_planeID on <schema>.Part (planeID)
 ;
 

--- a/caom2persistence/src/main/resources/postgresql/caom2.Plane.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.Plane.sql
@@ -1,5 +1,5 @@
 
-create table caom2.Plane
+create table <schema>.Plane
 (
     productID varchar(64) not null,
     publisherID varchar(512) not null,
@@ -84,7 +84,7 @@ create table caom2.Plane
     metaReadAccessGroups tsvector default '',
 
 -- internal
-    obsID uuid not null references caom2.Observation (obsID),
+    obsID uuid not null references <schema>.Observation (obsID),
     planeID uuid not null  primary key,
     lastModified timestamp not null,
     maxLastModified timestamp not null,
@@ -95,29 +95,29 @@ create table caom2.Plane
 ;
 
 -- this is for Observation join Plane
-create index i_obsID on caom2.Plane (obsID)
+create index i_obsID on <schema>.Plane (obsID)
 ;
 
 -- tag the clustering index
-cluster i_obsID on caom2.Plane
+cluster i_obsID on <schema>.Plane
 ;
 
-create table caom2.Plane_inputs
+create table <schema>.Plane_inputs
 (
-    outputID uuid not null references caom2.Plane (planeID),
-    inputID uuid not null references caom2.Plane (planeID)
+    outputID uuid not null references <schema>.Plane (planeID),
+    inputID uuid not null references <schema>.Plane (planeID)
 )
 ;
 
-create unique index i_publisherID on caom2.Plane(publisherID)
+create unique index i_publisherID on <schema>.Plane(publisherID)
 ;
 
-create unique index i_creatorID on caom2.Plane(creatorID)
+create unique index i_creatorID on <schema>.Plane(creatorID)
 ;
 
-create unique index i_output2input on caom2.Plane_inputs (outputID,inputID)
+create unique index i_output2input on <schema>.Plane_inputs (outputID,inputID)
 ;
 
-create unique index i_input2output on caom2.Plane_inputs (inputID,outputID)
+create unique index i_input2output on <schema>.Plane_inputs (inputID,outputID)
 ;
 

--- a/caom2persistence/src/main/resources/postgresql/caom2.SIAv1.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.SIAv1.sql
@@ -1,5 +1,5 @@
 
-create or replace view caom2.SIAv1
+create or replace view <schema>.SIAv1
 (
     collection, publisherDID, instrument_name,
 
@@ -48,7 +48,7 @@ a.contentType,
 p.metaRelease, p.dataRelease, p.metaReadAccessGroups,
 p.planeID
 
-FROM caom2.Observation o JOIN caom2.Plane p ON o.obsID=p.obsID JOIN caom2.Artifact a on p.planeID=a.planeID
+FROM <schema>.Observation o JOIN <schema>.Plane p ON o.obsID=p.obsID JOIN <schema>.Artifact a on p.planeID=a.planeID
 WHERE 
 -- science data only as in ObsCore
   o.intent = 'science' 
@@ -60,6 +60,6 @@ WHERE
 -- SIAv1 specific filtering
   AND p.dataProductType = 'image'
   AND (a.productType = 'science'
-    OR a.productType IS NULL) -- OR to allow HST science data through without joining to caom2.Part
+    OR a.productType IS NULL) -- OR to allow HST science data through without joining to <schema>.Part
   AND (o.collection != 'OMM' OR a.uri NOT LIKE '%prev') -- hack for OMM data engineering issue
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.access.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.access.sql
@@ -1,6 +1,6 @@
 
 -- ObservationMetaReadAccess --
-create table caom2.ObservationMetaReadAccess
+create table <schema>.ObservationMetaReadAccess
 (
     assetID         uuid not null,
     groupID         varchar(128) not null,
@@ -13,11 +13,11 @@ create table caom2.ObservationMetaReadAccess
 ;
 
 create unique index i_omra_tuple 
-    on caom2.ObservationMetaReadAccess (groupID, assetID)
+    on <schema>.ObservationMetaReadAccess (groupID, assetID)
 ;
 
 -- PlaneMetaReadAccess --
-create table caom2.PlaneMetaReadAccess
+create table <schema>.PlaneMetaReadAccess
 (
     assetID         uuid not null,
     groupID         varchar(128) not null,
@@ -30,11 +30,11 @@ create table caom2.PlaneMetaReadAccess
 ;
 
 create unique index i_pmra_tuple 
-    on caom2.PlaneMetaReadAccess (groupID, assetID)
+    on <schema>.PlaneMetaReadAccess (groupID, assetID)
 ;
 
 -- PlaneDataReadAccess --
-create table caom2.PlaneDataReadAccess
+create table <schema>.PlaneDataReadAccess
 (
     assetID         uuid not null, 
     groupID         varchar(128) not null,
@@ -47,5 +47,5 @@ create table caom2.PlaneDataReadAccess
 ;
 
 create unique index i_pdra_tuple 
-    on caom2.PlaneDataReadAccess (groupID, assetID)
+    on <schema>.PlaneDataReadAccess (groupID, assetID)
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.deleted.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.deleted.sql
@@ -1,36 +1,36 @@
 
-create table caom2.DeletedObservation
+create table <schema>.DeletedObservation
 (
     id uuid not null,
     lastModified timestamp not null
 )
 ;
-create index i_delobs_lastModified on caom2.DeletedObservation (lastModified)
+create index i_delobs_lastModified on <schema>.DeletedObservation (lastModified)
 ;
 
-create table caom2.DeletedObservationMetaReadAccess
+create table <schema>.DeletedObservationMetaReadAccess
 (
     id uuid not null,
     lastModified timestamp not null
 )
 ;
-create index i_delomra_lastModified on caom2.DeletedObservationMetaReadAccess (lastModified)
+create index i_delomra_lastModified on <schema>.DeletedObservationMetaReadAccess (lastModified)
 ;
 
-create table caom2.DeletedPlaneMetaReadAccess
+create table <schema>.DeletedPlaneMetaReadAccess
 (
     id uuid not null,
     lastModified timestamp not null
 )
 ;
-create index i_delpmra_lastModified on caom2.DeletedPlaneMetaReadAccess (lastModified)
+create index i_delpmra_lastModified on <schema>.DeletedPlaneMetaReadAccess (lastModified)
 ;
 
-create table caom2.DeletedPlaneDataReadAccess
+create table <schema>.DeletedPlaneDataReadAccess
 (
     id uuid not null,
     lastModified timestamp not null
 )
 ;
-create index i_delpdra_lastModified on caom2.DeletedPlaneDataReadAccess (lastModified)
+create index i_delpdra_lastModified on <schema>.DeletedPlaneDataReadAccess (lastModified)
 ;

--- a/caom2persistence/src/main/resources/postgresql/caom2.drop_all.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.drop_all.sql
@@ -1,29 +1,29 @@
 
-drop view if exists caom2.ObsPart;
-drop view if exists caom2.ObsFile;
-drop view if exists caom2.ObsCore;
-drop view if exists caom2.SIAv1;
+drop view if exists <schema>.ObsPart;
+drop view if exists <schema>.ObsFile;
+drop view if exists <schema>.ObsCore;
+drop view if exists <schema>.SIAv1;
 
-drop table if exists caom2.Chunk;
-drop table if exists caom2.Part;
-drop table if exists caom2.Artifact;
-drop table if exists caom2.Plane_inputs;
-drop table if exists caom2.Plane;
-drop table if exists caom2.Observation_members;
-drop table if exists caom2.Observation;
+drop table if exists <schema>.Chunk;
+drop table if exists <schema>.Part;
+drop table if exists <schema>.Artifact;
+drop table if exists <schema>.Plane_inputs;
+drop table if exists <schema>.Plane;
+drop table if exists <schema>.Observation_members;
+drop table if exists <schema>.Observation;
 
-drop table if exists caom2.ObservationMetaReadAccess;
-drop table if exists caom2.PlaneMetaReadAccess;
-drop table if exists caom2.PlaneDataReadAccess;
+drop table if exists <schema>.ObservationMetaReadAccess;
+drop table if exists <schema>.PlaneMetaReadAccess;
+drop table if exists <schema>.PlaneDataReadAccess;
 
-drop table if exists caom2.DeletedObservation;
-drop table if exists caom2.DeletedObservationMetaReadAccess;
-drop table if exists caom2.DeletedPlaneMetaReadAccess;
-drop table if exists caom2.DeletedPlaneDataReadAccess;
+drop table if exists <schema>.DeletedObservation;
+drop table if exists <schema>.DeletedObservationMetaReadAccess;
+drop table if exists <schema>.DeletedPlaneMetaReadAccess;
+drop table if exists <schema>.DeletedPlaneDataReadAccess;
 
-drop table if exists caom2.HarvestState;
-drop table if exists caom2.HarvestSkip;
-drop table if exists caom2.HarvestSkipURI;
+drop table if exists <schema>.HarvestState;
+drop table if exists <schema>.HarvestSkip;
+drop table if exists <schema>.HarvestSkipURI;
 
-drop table if exists caom2.ModelVersion;
+drop table if exists <schema>.ModelVersion;
 

--- a/caom2persistence/src/main/resources/postgresql/caom2.extra_indices.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.extra_indices.sql
@@ -1,136 +1,136 @@
 
 -- position
 create index Plane_position_i1
-    on caom2.Plane using gist (position_bounds)
+    on <schema>.Plane using gist (position_bounds)
 ;
 
 create index Plane_position_i2
-    on caom2.Plane using gist (position_bounds_center)
+    on <schema>.Plane using gist (position_bounds_center)
 ;
 create index Plane_position_i3
-    on caom2.Plane (position_bounds_area)
+    on <schema>.Plane (position_bounds_area)
 ;
 
 -- energy
 create index Plane_energy_ib
-    on caom2.Plane using gist (energy_bounds)
+    on <schema>.Plane using gist (energy_bounds)
 ;
 create index Plane_energy_ibw
-    on caom2.Plane (energy_bounds_width)
+    on <schema>.Plane (energy_bounds_width)
 ;
 
 create index Plane_energy_ib1
-    on caom2.Plane (energy_bounds_lower)
+    on <schema>.Plane (energy_bounds_lower)
 ;
 create index Plane_energy_ib2
-    on caom2.Plane (energy_bounds_upper)
+    on <schema>.Plane (energy_bounds_upper)
 ;
 
 create index Plane_energy_iss
-    on caom2.Plane (energy_sampleSize)
+    on <schema>.Plane (energy_sampleSize)
 ;
 
 create index Plane_energy_irw
-    on caom2.Plane (energy_restwav)
+    on <schema>.Plane (energy_restwav)
 where energy_restwav is not null
 ;
 
 -- time
 create index Plane_time_ib
-    on caom2.Plane using gist (time_bounds)
+    on <schema>.Plane using gist (time_bounds)
 ;
 create index Plane_time_ibw
-    on caom2.Plane (time_bounds_width)
+    on <schema>.Plane (time_bounds_width)
 ;
 
 create index Plane_time_ib1
-    on caom2.Plane (time_bounds_lower)
+    on <schema>.Plane (time_bounds_lower)
 ;
 create index Plane_time_ib2
-    on caom2.Plane (time_bounds_upper)
+    on <schema>.Plane (time_bounds_upper)
 ;
 
 create index Plane_polar_is
-    on caom2.Plane (polarization_states)
+    on <schema>.Plane (polarization_states)
 ;
 
 -- case-sensitive
 create index i_collection_instrument
-    on caom2.Observation (collection, instrument_name)
+    on <schema>.Observation (collection, instrument_name)
 ;
 
 -- hardware config: telescope,instrument
 create index i_telescope_instrument
-    on caom2.Observation (telescope_name, instrument_name)
+    on <schema>.Observation (telescope_name, instrument_name)
 ;
 
 -- astronomical result search: emBand,dataProductType,calibrationLevel
 create index Plane_i_emBand_dataProductType
-    on caom2.Plane (energy_emBand,dataProductType)
+    on <schema>.Plane (energy_emBand,dataProductType)
 ;
 
 -- aka filter 
 create index i_bandpassName
-    on caom2.Plane (energy_bandpassName)
+    on <schema>.Plane (energy_bandpassName)
 ;
 
 create index i_provenance_runid
-    on caom2.Plane (provenance_runID)
+    on <schema>.Plane (provenance_runID)
 ;
 
 -- case-insensitive
 
 create index Observation_i_observationID_lower
-    on caom2.Observation ( lower(observationID) )
+    on <schema>.Observation ( lower(observationID) )
 ;
 
 create index Observation_i_targ_lower
-    on caom2.Observation ( (lower(target_name)) )
+    on <schema>.Observation ( (lower(target_name)) )
 ;
 
 create index Observation_i_proposal_id_lower
-    on caom2.Observation ( lower(proposal_id) )
+    on <schema>.Observation ( lower(proposal_id) )
 ;
 
 -- support both case-insensitive and LIKE via special operator
 
 create index Observation_i_observationID_lower_pattern
-    on caom2.Observation ( lower(observationID)  varchar_pattern_ops )
+    on <schema>.Observation ( lower(observationID)  varchar_pattern_ops )
 ;
 
 create index Observation_i_targ_lower_pattern
-    on caom2.Observation ( (lower(target_name))  varchar_pattern_ops )
+    on <schema>.Observation ( (lower(target_name))  varchar_pattern_ops )
 ;
 
 create index Observation_i_proposal_id_lower_pattern
-    on caom2.Observation ( lower(proposal_id)  varchar_pattern_ops )
+    on <schema>.Observation ( lower(proposal_id)  varchar_pattern_ops )
 ;
 
 create index Plane_i_dataRelease
-    on caom2.Plane ( dataRelease )
+    on <schema>.Plane ( dataRelease )
 ;
 
 -- support for SODA service and file authorization queries 
 create index Artifact_i_uri
-    on caom2.Artifact ( uri )
+    on <schema>.Artifact ( uri )
 ;
 
 --create index Observation_i_tel_kw
---    on caom2.Observation (telescope_keywords)
+--    on <schema>.Observation (telescope_keywords)
 --;
 
 --create index Observation_i_instr_kw
---    on caom2.Observation (instrument_keywords)
+--    on <schema>.Observation (instrument_keywords)
 --;
 
 --create index Observation_i_targ_kw
---    on caom2.Observation (target_keywords)
+--    on <schema>.Observation (target_keywords)
 --;
 
 --create index Observation_i_prop_kw
---    on caom2.Observation (proposal_keywords)
+--    on <schema>.Observation (proposal_keywords)
 --;
 
 --create index Plane_i_prov_kw
---    on caom2.Plane (provenance_keywords)
+--    on <schema>.Plane (provenance_keywords)
 --;

--- a/caom2persistence/src/main/resources/postgresql/caom2.truncate_all.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.truncate_all.sql
@@ -1,23 +1,23 @@
 
-truncate table caom2.Plane_inputs;
-truncate table caom2.Observation_members;
+truncate table <schema>.Plane_inputs;
+truncate table <schema>.Observation_members;
 
-truncate table caom2.Chunk;
-delete from caom2.Part;
-delete from caom2.Artifact;
-delete from caom2.Plane;
-delete from caom2.Observation;
+truncate table <schema>.Chunk;
+truncate table <schema>.Part;
+truncate table <schema>.Artifact;
+truncate table <schema>.Plane;
+truncate table <schema>.Observation;
 
-truncate table caom2.DeletedObservation;
+truncate table <schema>.DeletedObservation;
 
-truncate table caom2.ObservationMetaReadAccess;
-truncate table caom2.PlaneMetaReadAccess;
-truncate table caom2.PlaneDataReadAccess;
+truncate table <schema>.ObservationMetaReadAccess;
+truncate table <schema>.PlaneMetaReadAccess;
+truncate table <schema>.PlaneDataReadAccess;
 
-truncate table caom2.DeletedObservationMetaReadAccess;
-truncate table caom2.DeletedPlaneMetaReadAccess;
-truncate table caom2.DeletedPlaneDataReadAccess;
+truncate table <schema>.DeletedObservationMetaReadAccess;
+truncate table <schema>.DeletedPlaneMetaReadAccess;
+truncate table <schema>.DeletedPlaneDataReadAccess;
 
-truncate table caom2.HarvestState;
-truncate table caom2.HarvestSkip;
-truncate table caom2.HarvestSkipURI;
+truncate table <schema>.HarvestState;
+truncate table <schema>.HarvestSkip;
+truncate table <schema>.HarvestSkipURI;

--- a/caom2persistence/src/main/resources/postgresql/caom2.upgrade-2.3.5.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.upgrade-2.3.5.sql
@@ -1,18 +1,18 @@
 
-drop view if exists caom2.ObsPart;
-drop view if exists caom2.ObsFile;
-drop view if exists caom2.ObsCore;
-drop view if exists caom2.SIAv1;
+drop view if exists <schema>.ObsPart;
+drop view if exists <schema>.ObsFile;
+drop view if exists <schema>.ObsCore;
+drop view if exists <schema>.SIAv1;
 
 -- bug fix: correct handling of keywords
-drop index caom2.Observation_i_instr_kw;
-drop index caom2.Observation_i_prop_kw;
-drop index caom2.Observation_i_targ_kw;
-drop index caom2.Observation_i_tel_kw;
-drop index caom2.Plane_i_prov_kw;
+drop index <schema>.Observation_i_instr_kw;
+drop index <schema>.Observation_i_prop_kw;
+drop index <schema>.Observation_i_targ_kw;
+drop index <schema>.Observation_i_tel_kw;
+drop index <schema>.Plane_i_prov_kw;
 
 -- keyword handling change: tsvector to citext with | separator
-alter table caom2.Observation
+alter table <schema>.Observation
     alter column instrument_keywords type citext
         using replace(replace(instrument_keywords::varchar,$$'$$,''),' ','|'),
     alter column proposal_keywords type citext
@@ -23,23 +23,23 @@ alter table caom2.Observation
         using replace(replace(telescope_keywords::varchar,$$'$$,''),' ','|');
 
 --\echo altering keywords column (plane)...
-alter table caom2.Plane
+alter table <schema>.Plane
     alter column provenance_keywords type citext
         using replace(replace(provenance_keywords::varchar,$$'$$,''),' ','|');
 
 -- bug fix: rename columns to match model
-alter table caom2.Plane
+alter table <schema>.Plane
     rename column position_dimension1 to position_dimension_naxis1;
-alter table caom2.Plane
+alter table <schema>.Plane
     rename column position_dimension2 to position_dimension_naxis2;
 
 -- bug fix: correct support for IVOA/DALI datatypes and richer caom2 polygons
-alter table caom2.Plane
+alter table <schema>.Plane
     add column position_bounds_points double precision[],
     add column position_bounds_samples double precision[],
     add column energy_bounds_samples polygon,
     add column time_bounds_samples polygon;
 
 -- preserve bounds values we previously stored in the wrong column
-update caom2.Plane 
+update <schema>.Plane 
     set (energy_bounds_samples,time_bounds_samples) = (energy_bounds, time_bounds);

--- a/caom2persistence/src/main/resources/postgresql/caom2.upgrade-23.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.upgrade-23.sql
@@ -1,35 +1,35 @@
 
 -- checksum length 136 allows for 128 chars (sha512) + colon + 7 char algorithm
 
-alter table caom2.Observation
+alter table <schema>.Observation
     add column metaChecksum varchar(136),
     add column accMetaChecksum varchar(136);
     
-alter table caom2.Plane
+alter table <schema>.Plane
     add column creatorID varchar(512),
     add column metaChecksum varchar(136),
     add column accMetaChecksum varchar(136);
 
-alter table caom2.Artifact
+alter table <schema>.Artifact
     add column contentChecksum varchar(136),
     add column metaChecksum varchar(136),
     add column accMetaChecksum varchar(136);
 
-alter table caom2.Part
+alter table <schema>.Part
     add column metaChecksum varchar(136),
     add column accMetaChecksum varchar(136);
 
-alter table caom2.Chunk
+alter table <schema>.Chunk
     add column metaChecksum varchar(136),
     add column accMetaChecksum varchar(136);
 
-alter table caom2.ObservationMetaReadAccess
+alter table <schema>.ObservationMetaReadAccess
     add column metaChecksum varchar(136);
 
-alter table caom2.PlaneMetaReadAccess
+alter table <schema>.PlaneMetaReadAccess
     add column metaChecksum varchar(136);
 
-alter table caom2.PlaneDataReadAccess
+alter table <schema>.PlaneDataReadAccess
     add column metaChecksum varchar(136);
 
-create unique index i_creatorID on caom2.Plane(creatorID);
+create unique index i_creatorID on <schema>.Plane(creatorID);

--- a/caom2persistence/src/main/resources/postgresql/caom2.vacuum-analyze.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.vacuum-analyze.sql
@@ -1,11 +1,11 @@
 
-VACUUM VERBOSE ANALYZE caom2.Observation;
-VACUUM VERBOSE ANALYZE caom2.Plane;
-VACUUM VERBOSE ANALYZE caom2.Artifact;
-VACUUM VERBOSE ANALYZE caom2.Part;
-VACUUM VERBOSE ANALYZE caom2.Chunk;
+VACUUM VERBOSE ANALYZE <schema>.Observation;
+VACUUM VERBOSE ANALYZE <schema>.Plane;
+VACUUM VERBOSE ANALYZE <schema>.Artifact;
+VACUUM VERBOSE ANALYZE <schema>.Part;
+VACUUM VERBOSE ANALYZE <schema>.Chunk;
 
-VACUUM VERBOSE ANALYZE caom2.ObservationMetaReadAccess;
-VACUUM VERBOSE ANALYZE caom2.PlaneMetaReadAccess;
-VACUUM VERBOSE ANALYZE caom2.PlaneDataReadAccess;
+VACUUM VERBOSE ANALYZE <schema>.ObservationMetaReadAccess;
+VACUUM VERBOSE ANALYZE <schema>.PlaneMetaReadAccess;
+VACUUM VERBOSE ANALYZE <schema>.PlaneDataReadAccess;
 


### PR DESCRIPTION
Modifications in caom2persistenc to remove hardcoded schema name in DB initialisation procedure.

Note: Commented line 421 of caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java to avoid compilation errors: CaomValidator.validateKeywords() is a private method. Flagged with "TODO".