### PR TITLE
Repo Client Refactoring to allow URL-based Repo Client

### DIFF
--- a/caom2-repo/build.gradle
+++ b/caom2-repo/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1'
+version = '1.2'
 
 mainClassName = 'ca.nrc.cadc.caom2.repo.client.Main'
 

--- a/caom2-repo/build.gradle
+++ b/caom2-repo/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.2'
+version = '1.3'
 
 mainClassName = 'ca.nrc.cadc.caom2.repo.client.Main'
 

--- a/caom2-repo/src/intTest/java/ca/nrc/cadc/caom2/repo/client/HttpRepoClientTest.java
+++ b/caom2-repo/src/intTest/java/ca/nrc/cadc/caom2/repo/client/HttpRepoClientTest.java
@@ -1,0 +1,259 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2011.                            (c) 2011.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 5 $
+*
+************************************************************************
+*/
+
+package ca.nrc.cadc.caom2.repo.client;
+
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessControlException;
+import java.security.PrivilegedExceptionAction;
+import java.util.List;
+
+import javax.security.auth.Subject;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.nrc.cadc.auth.AuthenticationUtil;
+import ca.nrc.cadc.caom2.ObservationResponse;
+import ca.nrc.cadc.caom2.ObservationState;
+import ca.nrc.cadc.caom2.ObservationURI;
+import ca.nrc.cadc.net.NetrcAuthenticator;
+import ca.nrc.cadc.util.Log4jInit;
+
+public class HttpRepoClientTest {
+
+    private static final Logger log = Logger.getLogger(HttpRepoClientTest.class);
+
+    static {
+        Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client.UrlBasedRepoClient", Level.DEBUG);
+        // Log4jInit.setLevel("ca.nrc.cadc.reg", Level.DEBUG);
+    }
+
+    // @Test
+    public void testTemplate() {
+        try {
+
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+    @Test
+    public void testGetObservationList() {
+        try {
+            Subject s = AuthenticationUtil.getSubject(new NetrcAuthenticator(true));
+            Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
+
+                @Override
+                public Object run() throws Exception {
+                    RepoClient repoC = new HttpRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 
+                    										8,
+                    										new URL("http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2repo/auth-obs23"),
+                    										null);
+
+                    List<ObservationState> list = repoC.getObservationList("IRIS", null, null, 5);
+                    Assert.assertEquals(list.size(), 6);
+                    // Assert.assertEquals(URI.create("caom:IRIS/f001h000"),
+                    // list.get(0).getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f002h000"),
+                    // list.get(1).getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f003h000"),
+                    // list.get(2).getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f004h000"),
+                    // list.get(3).getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f005h000"),
+                    // list.get(4).getURI().getURI());
+
+                    return null;
+                }
+            });
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+    @Test
+    public void testGetObservationListStsci() {
+        try {
+            Subject s = AuthenticationUtil.getAnonSubject();
+            Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
+
+                @Override
+                public Object run() throws Exception {
+                    RepoClient repoC = new HttpRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 
+							8,
+							new URL("http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2repo/auth-obs23"),
+							null);;
+
+                    List<ObservationState> list = repoC.getObservationList("HST", null, null, 5);
+                    Assert.assertEquals(list.size(), 6);
+
+                    return null;
+                }
+            });
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+    @Test
+    public void testGetObservationListDenied() {
+        try {
+            Subject s = AuthenticationUtil.getAnonSubject();
+            Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
+
+                @Override
+                public Object run() throws Exception {
+                    RepoClient repoC = new HttpRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 
+							8,
+							new URL("http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2repo/obs23"),
+							null);
+
+                    List<ObservationState> list = repoC.getObservationList("IRIS", null, null, 5);
+                    Assert.fail("expected exception, got results");
+
+                    return null;
+                }
+            });
+        } catch (AccessControlException expected) {
+            log.info("caught expected exception: " + expected);
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+    @Test
+    public void testGetList() {
+        try {
+            Subject s = AuthenticationUtil.getSubject(new NetrcAuthenticator(true));
+            Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
+
+                @Override
+                public Object run() throws Exception {
+                    RepoClient repoC = new HttpRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 
+							8,
+							new URL("http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2repo/auth-obs23"),
+							null);
+
+                    List<ObservationResponse> list = repoC.getList("IRIS", null, null, 5);
+                    Assert.assertEquals(list.size(), 6);
+                    // Assert.assertEquals(URI.create("caom:IRIS/f001h000"),
+                    // list.get(0).getObservation().getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f002h000"),
+                    // list.get(1).getObservation().getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f003h000"),
+                    // list.get(2).getObservation().getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f004h000"),
+                    // list.get(3).getObservation().getURI().getURI());
+                    // Assert.assertEquals(URI.create("caom:IRIS/f005h000"),
+                    // list.get(4).getObservation().getURI().getURI());
+
+                    return null;
+                }
+            });
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+    @Test
+    public void testGet() {
+        try {
+            Subject s = AuthenticationUtil.getSubject(new NetrcAuthenticator(true));
+            Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
+
+                @Override
+                public Object run() throws Exception {
+                    RepoClient repoC = new HttpRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 
+							8,
+							new URL("http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2repo/auth-obs23"),
+							null);
+
+                    ObservationResponse wr = repoC.get(new ObservationURI("IRIS", "f001h000"));
+                    Assert.assertNotNull(wr.observation);
+                    Assert.assertEquals(wr.observation.getID().toString(), "00000000-0000-0000-897c-013ac26a8f32");
+
+                    return null;
+                }
+            });
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+}

--- a/caom2-repo/src/intTest/java/ca/nrc/cadc/caom2/repo/client/RegisteredRepoClientTest.java
+++ b/caom2-repo/src/intTest/java/ca/nrc/cadc/caom2/repo/client/RegisteredRepoClientTest.java
@@ -88,12 +88,12 @@ import ca.nrc.cadc.caom2.ObservationURI;
 import ca.nrc.cadc.net.NetrcAuthenticator;
 import ca.nrc.cadc.util.Log4jInit;
 
-public class RepoClientTest {
+public class RegisteredRepoClientTest {
 
-    private static final Logger log = Logger.getLogger(RepoClientTest.class);
+    private static final Logger log = Logger.getLogger(RegisteredRepoClientTest.class);
 
     static {
-        Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client.RepoClient", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client.RegistryBasedRepoClient", Level.DEBUG);
         // Log4jInit.setLevel("ca.nrc.cadc.reg", Level.DEBUG);
     }
 
@@ -115,7 +115,7 @@ public class RepoClientTest {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
+                    RepoClient repoC = new RegisteredRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
 
                     List<ObservationState> list = repoC.getObservationList("IRIS", null, null, 5);
                     Assert.assertEquals(list.size(), 6);
@@ -147,7 +147,7 @@ public class RepoClientTest {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://mast.stsci.edu/caom2repo"), 8);
+                    RepoClient repoC = new RegisteredRepoClient(URI.create("ivo://mast.stsci.edu/caom2repo"), 8);
 
                     List<ObservationState> list = repoC.getObservationList("HST", null, null, 5);
                     Assert.assertEquals(list.size(), 6);
@@ -169,7 +169,7 @@ public class RepoClientTest {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
+                    RepoClient repoC = new RegisteredRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
 
                     List<ObservationState> list = repoC.getObservationList("IRIS", null, null, 5);
                     Assert.fail("expected exception, got results");
@@ -193,7 +193,7 @@ public class RepoClientTest {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
+                    RepoClient repoC = new RegisteredRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
 
                     List<ObservationResponse> list = repoC.getList("IRIS", null, null, 5);
                     Assert.assertEquals(list.size(), 6);
@@ -225,7 +225,7 @@ public class RepoClientTest {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
+                    RepoClient repoC = new RegisteredRepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
 
                     ObservationResponse wr = repoC.get(new ObservationURI("IRIS", "f001h000"));
                     Assert.assertNotNull(wr.observation);

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/AbstractRepoClient.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/AbstractRepoClient.java
@@ -1,71 +1,71 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2011.                            (c) 2011.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2011.                            (c) 2011.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.caom2.repo.client;
 
@@ -102,7 +102,7 @@ import javax.security.auth.Subject;
 
 import org.apache.log4j.Logger;
 
-public abstract class AbstractRepoClient implements RepoClient{
+public abstract class AbstractRepoClient implements RepoClient {
 
     private static final Logger log = Logger.getLogger(AbstractRepoClient.class);
     private static final Integer MAX_NUMBER = 3000;
@@ -129,7 +129,7 @@ public abstract class AbstractRepoClient implements RepoClient{
             return o1.observationState.maxLastModified.compareTo(o2.observationState.maxLastModified);
         }
     };
-    
+
     /**
      * Create new CAOM RepoClient.
      *
@@ -138,36 +138,40 @@ public abstract class AbstractRepoClient implements RepoClient{
      * @param nthreads
      *            number of threads to use when getting list of observations
      */
-    
-    public AbstractRepoClient(URI resourceID, int nthreads){
-    	this.resourceID=resourceID;
-    	this.nthreads=nthreads;
+
+    public AbstractRepoClient(URI resourceID, int nthreads) {
+        this.resourceID = resourceID;
+        this.nthreads = nthreads;
     }
-    
-    
+
     protected abstract void init();
-    
+
     protected abstract void initDel();
 
-	@Override
-	public List<DeletedObservation> getDeleted(String collection, Date start, Date end, Integer maxrec) {
+    @Override
+    public List<DeletedObservation> getDeleted(String collection, Date start, Date end, Integer maxrec) {
         initDel();
 
         final List<DeletedObservation> ret = new ArrayList<>();
 
-        // TODO: make call(s) to the deletion endpoint until requested number of entries (like getObservationList)
+        // TODO: make call(s) to the deletion endpoint until requested number of
+        // entries (like getObservationList)
 
-        // parse each line into the following 4 values, create DeletedObservation, and add to output list, eg:
+        // parse each line into the following 4 values, create
+        // DeletedObservation, and add to output list, eg:
         /*
-         * UUID id = null; String col = null; String observationID = null; Date lastModified = null; DeletedObservation de = new DeletedObservation(id, new
-         * ObservationURI(col, observationID)); CaomUtil.assignLastModified(de, lastModified, "lastModified"); ret.add(de);
+         * UUID id = null; String col = null; String observationID = null; Date
+         * lastModified = null; DeletedObservation de = new
+         * DeletedObservation(id, new ObservationURI(col, observationID));
+         * CaomUtil.assignLastModified(de, lastModified, "lastModified");
+         * ret.add(de);
          */
 
         return ret;
     }
 
-	@Override
-	public List<ObservationState> getObservationList(String collection, Date start, Date end, Integer maxrec) throws AccessControlException {
+    @Override
+    public List<ObservationState> getObservationList(String collection, Date start, Date end, Integer maxrec) throws AccessControlException {
         init();
 
         List<ObservationState> accList = new ArrayList<>();
@@ -209,10 +213,13 @@ public abstract class AbstractRepoClient implements RepoClient{
                 int responseCode = get.getResponseCode();
                 log.debug("RESPONSE CODE: '" + responseCode + "'");
                 /*
-                 * if (responseCode == 302) // redirected url { url = get.getRedirectURL(); log.debug("REDIRECTED URL: " + url); bos = new
-                 * ByteArrayOutputStream(); get = new HttpDownload(url, bos); responseCode = get.getResponseCode();
-                 * log.debug("RESPONSE CODE (REDIRECTED URL): '" + responseCode + "'");
-                 *
+                 * if (responseCode == 302) // redirected url { url =
+                 * get.getRedirectURL(); log.debug("REDIRECTED URL: " + url);
+                 * bos = new ByteArrayOutputStream(); get = new
+                 * HttpDownload(url, bos); responseCode = get.getResponseCode();
+                 * log.debug("RESPONSE CODE (REDIRECTED URL): '" + responseCode
+                 * + "'");
+                 * 
                  * }
                  */
 
@@ -270,9 +277,9 @@ public abstract class AbstractRepoClient implements RepoClient{
         return partialList;
     }
 
-	@Override
-	public List<ObservationResponse> getList(String collection, Date startDate, Date end, Integer numberOfObservations)
-            throws InterruptedException, ExecutionException {
+    @Override
+    public List<ObservationResponse> getList(String collection, Date startDate, Date end, Integer numberOfObservations) throws InterruptedException,
+            ExecutionException {
         init();
 
         // startDate = null;
@@ -323,8 +330,8 @@ public abstract class AbstractRepoClient implements RepoClient{
         return list;
     }
 
-	@Override
-	public ObservationResponse get(ObservationURI uri) {
+    @Override
+    public ObservationResponse get(ObservationURI uri) {
         init();
         if (uri == null) {
             throw new IllegalArgumentException("uri cannot be null");
@@ -338,18 +345,18 @@ public abstract class AbstractRepoClient implements RepoClient{
         return wt.getObservation();
     }
 
-	@Override
-	public List<ObservationResponse> get(List<ObservationURI> listURI) throws InterruptedException, ExecutionException {
+    @Override
+    public List<ObservationResponse> get(List<ObservationURI> listURI) throws InterruptedException, ExecutionException {
         init();
         if (listURI == null) {
             throw new IllegalArgumentException("list of uri cannot be null");
         }
-        //****************
+        // ****************
         List<ObservationResponse> list = new ArrayList<>();
         // Create tasks for each file
         List<Callable<ObservationResponse>> tasks = new ArrayList<>();
 
-        // want to put the result list back in same order as the input list; 
+        // want to put the result list back in same order as the input list;
         // maxLasModifiedComparatorForResponse sorts by state.maxLastModified
         // so fake it with date values that increase
         Date now = new Date();
@@ -386,11 +393,11 @@ public abstract class AbstractRepoClient implements RepoClient{
         }
         Collections.sort(list, maxLasModifiedComparatorForResponse);
 
-        //****************
+        // ****************
         return list;
     }
 
-	@Override
+    @Override
     public ObservationResponse get(String collection, URI uri, Date start) {
         if (uri == null) {
             throw new IllegalArgumentException("uri cannot be null");
@@ -424,8 +431,8 @@ public abstract class AbstractRepoClient implements RepoClient{
 
     private List<ObservationState> transformByteArrayOutputStreamIntoListOfObservationState(final ByteArrayOutputStream bos, DateFormat sdf, char separator,
             char endOfLine)
-
-            throws ParseException, IOException, URISyntaxException {
+        throws ParseException, IOException, URISyntaxException {
+        
         init();
 
         List<ObservationState> list = new ArrayList<>();
@@ -519,34 +526,34 @@ public abstract class AbstractRepoClient implements RepoClient{
 
     }
 
-	@Override
-	public URI getResourceID() {
-		return resourceID;
-	}
+    @Override
+    public URI getResourceID() {
+        return resourceID;
+    }
 
-	@Override
-	public int getNthreads() {
-		return nthreads;
-	}
+    @Override
+    public int getNthreads() {
+        return nthreads;
+    }
 
-	@Override
-	public URL getBaseServiceURL() {
-		return baseServiceURL;
-	}
+    @Override
+    public URL getBaseServiceURL() {
+        return baseServiceURL;
+    }
 
-	@Override
-	public void setBaseServiceURL(URL baseServiceURL) {
-		this.baseServiceURL=baseServiceURL;
-	}
+    @Override
+    public void setBaseServiceURL(URL baseServiceURL) {
+        this.baseServiceURL = baseServiceURL;
+    }
 
-	@Override
-	public URL getBaseDeletionURL() {
-		return baseDeletionURL;
-	}
+    @Override
+    public URL getBaseDeletionURL() {
+        return baseDeletionURL;
+    }
 
-	@Override
-	public void setBaseDeletionURL(URL baseDeletionURL) {
-		this.baseDeletionURL=baseDeletionURL;
-	}
-    
+    @Override
+    public void setBaseDeletionURL(URL baseDeletionURL) {
+        this.baseDeletionURL = baseDeletionURL;
+    }
+
 }

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/AbstractRepoClient.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/AbstractRepoClient.java
@@ -1,0 +1,552 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2011.                            (c) 2011.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 5 $
+*
+************************************************************************
+*/
+
+package ca.nrc.cadc.caom2.repo.client;
+
+import ca.nrc.cadc.auth.AuthenticationUtil;
+import ca.nrc.cadc.caom2.DeletedObservation;
+import ca.nrc.cadc.caom2.ObservationResponse;
+import ca.nrc.cadc.caom2.ObservationState;
+import ca.nrc.cadc.caom2.ObservationURI;
+import ca.nrc.cadc.date.DateUtil;
+import ca.nrc.cadc.net.HttpDownload;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.AccessControlException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.security.auth.Subject;
+
+import org.apache.log4j.Logger;
+
+public abstract class AbstractRepoClient implements RepoClient{
+
+    private static final Logger log = Logger.getLogger(AbstractRepoClient.class);
+    private static final Integer MAX_NUMBER = 3000;
+
+    private final DateFormat df = DateUtil.getDateFormat(DateUtil.IVOA_DATE_FORMAT, DateUtil.UTC);
+    private URI resourceID = null;
+    private URL baseServiceURL = null;
+    private URL baseDeletionURL = null;
+
+    private int nthreads = 1;
+    private Comparator<ObservationState> maxLasModifiedComparatorForState = new Comparator<ObservationState>() {
+        @Override
+        public int compare(ObservationState o1, ObservationState o2) {
+            return o1.maxLastModified.compareTo(o2.maxLastModified);
+        }
+    };
+    private Comparator<ObservationResponse> maxLasModifiedComparatorForResponse = new Comparator<ObservationResponse>() {
+        @Override
+        public int compare(ObservationResponse o1, ObservationResponse o2) {
+            if (o1 == null || o2 == null || o1.observationState == null || o2.observationState == null || o1.observationState.maxLastModified == null
+                    || o2.observationState.maxLastModified == null) {
+                throw new NullPointerException();
+            }
+            return o1.observationState.maxLastModified.compareTo(o2.observationState.maxLastModified);
+        }
+    };
+    
+    /**
+     * Create new CAOM RepoClient.
+     *
+     * @param resourceID
+     *            the service identifier
+     * @param nthreads
+     *            number of threads to use when getting list of observations
+     */
+    
+    public AbstractRepoClient(URI resourceID, int nthreads){
+    	this.resourceID=resourceID;
+    	this.nthreads=nthreads;
+    }
+    
+    
+    protected abstract void init();
+    
+    protected abstract void initDel();
+
+	@Override
+	public List<DeletedObservation> getDeleted(String collection, Date start, Date end, Integer maxrec) {
+        initDel();
+
+        final List<DeletedObservation> ret = new ArrayList<>();
+
+        // TODO: make call(s) to the deletion endpoint until requested number of entries (like getObservationList)
+
+        // parse each line into the following 4 values, create DeletedObservation, and add to output list, eg:
+        /*
+         * UUID id = null; String col = null; String observationID = null; Date lastModified = null; DeletedObservation de = new DeletedObservation(id, new
+         * ObservationURI(col, observationID)); CaomUtil.assignLastModified(de, lastModified, "lastModified"); ret.add(de);
+         */
+
+        return ret;
+    }
+
+	@Override
+	public List<ObservationState> getObservationList(String collection, Date start, Date end, Integer maxrec) throws AccessControlException {
+        init();
+
+        List<ObservationState> accList = new ArrayList<>();
+        List<ObservationState> partialList = null;
+        boolean tooBigRequest = maxrec == null || maxrec > MAX_NUMBER;
+
+        Integer rec = maxrec;
+        Integer recCounter;
+        if (tooBigRequest) {
+            rec = MAX_NUMBER;
+        }
+        // Use HttpDownload to make the http GET calls (because it handles a lot
+        // of the
+        // authentication stuff)
+        boolean go = true;
+        String surlCommon = baseServiceURL.toExternalForm() + File.separator + collection;
+
+        while (go) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            if (!tooBigRequest) {
+                go = false;// only one go
+            }
+            String surl = surlCommon;
+            surl = surl + "?maxRec=" + (rec + 1);
+            if (start != null) {
+                surl = surl + "&start=" + df.format(start);
+            }
+            if (end != null) {
+                surl = surl + "&end=" + df.format(end);
+            }
+            URL url;
+            log.debug("URL: " + surl);
+            try {
+                url = new URL(surl);
+                HttpDownload get = new HttpDownload(url, bos);
+                get.setFollowRedirects(true);
+
+                get.run();
+                int responseCode = get.getResponseCode();
+                log.debug("RESPONSE CODE: '" + responseCode + "'");
+                /*
+                 * if (responseCode == 302) // redirected url { url = get.getRedirectURL(); log.debug("REDIRECTED URL: " + url); bos = new
+                 * ByteArrayOutputStream(); get = new HttpDownload(url, bos); responseCode = get.getResponseCode();
+                 * log.debug("RESPONSE CODE (REDIRECTED URL): '" + responseCode + "'");
+                 *
+                 * }
+                 */
+
+                if (get.getThrowable() != null) {
+                    if (get.getThrowable() instanceof AccessControlException) {
+                        throw (AccessControlException) get.getThrowable();
+                    }
+                    throw new RuntimeException("failed to get observation list", get.getThrowable());
+                }
+            } catch (MalformedURLException e) {
+                throw new RuntimeException("BUG: failed to generate observation list url", e);
+            }
+
+            try {
+                // log.debug("RESPONSE = '" + bos.toString() + "'");
+                partialList = transformByteArrayOutputStreamIntoListOfObservationState(bos, df, '\t', '\n');
+                if (partialList != null && !partialList.isEmpty() && !accList.isEmpty() && accList.get(accList.size() - 1).equals(partialList.get(0))) {
+                    partialList.remove(0);
+                }
+
+                if (partialList != null) {
+                    accList.addAll(partialList);
+                    log.debug("adding " + partialList.size() + " elements to accList. Now there are " + accList.size());
+                }
+
+                bos.close();
+            } catch (ParseException | URISyntaxException | IOException e) {
+                throw new RuntimeException("Unable to list of ObservationState from " + bos.toString(), e);
+            }
+
+            if (accList.size() > 0) {
+                start = accList.get(accList.size() - 1).maxLastModified;
+            }
+
+            recCounter = accList.size();
+            if (maxrec != null && maxrec - recCounter > 0 && maxrec - recCounter < rec) {
+                rec = maxrec - recCounter;
+            }
+            log.debug("dynamic batch (rec): " + rec);
+            log.debug("counter (recCounter): " + recCounter);
+            log.debug("maxrec: " + maxrec);
+            // log.debug("start: " + start.toString());
+            // log.debug("end: " + end.toString());
+
+            if (partialList != null) {
+                log.debug("partialList.size(): " + partialList.size());
+
+                if (partialList.size() < rec || (end != null && start != null && start.equals(end))) {
+                    log.debug("************** go false");
+
+                    go = false;
+                }
+            }
+        }
+        return partialList;
+    }
+
+	@Override
+	public List<ObservationResponse> getList(String collection, Date startDate, Date end, Integer numberOfObservations)
+            throws InterruptedException, ExecutionException {
+        init();
+
+        // startDate = null;
+        // end = df.parse("2017-06-20T09:03:15.360");
+        List<ObservationResponse> list = new ArrayList<>();
+
+        List<ObservationState> stateList = getObservationList(collection, startDate, end, numberOfObservations);
+
+        // Create tasks for each file
+        List<Callable<ObservationResponse>> tasks = new ArrayList<>();
+
+        // the current subject usually gets propagated into a thread pool, but
+        // gets attached
+        // when the thread is created so we explicitly pass it it and do another
+        // Subject.doAs in
+        // case
+        // thread pool management is changed
+        Subject subjectForWorkerThread = AuthenticationUtil.getCurrentSubject();
+        for (ObservationState os : stateList) {
+            tasks.add(new Worker(os, subjectForWorkerThread, baseServiceURL.toExternalForm()));
+        }
+
+        ExecutorService taskExecutor = null;
+        try {
+            // Run tasks in a fixed thread pool
+            taskExecutor = Executors.newFixedThreadPool(nthreads);
+            List<Future<ObservationResponse>> futures;
+
+            futures = taskExecutor.invokeAll(tasks);
+
+            for (Future<ObservationResponse> f : futures) {
+                ObservationResponse res = null;
+                res = f.get();
+
+                if (f.isDone()) {
+                    list.add(res);
+                }
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error when executing thread in ThreadPool: " + e.getMessage() + " caused by: " + e.getCause().toString());
+            throw e;
+        } finally {
+            if (taskExecutor != null) {
+                taskExecutor.shutdown();
+            }
+        }
+
+        return list;
+    }
+
+	@Override
+	public ObservationResponse get(ObservationURI uri) {
+        init();
+        if (uri == null) {
+            throw new IllegalArgumentException("uri cannot be null");
+        }
+
+        ObservationState os = new ObservationState(uri);
+
+        // see comment above in getList
+        Subject subjectForWorkerThread = AuthenticationUtil.getCurrentSubject();
+        Worker wt = new Worker(os, subjectForWorkerThread, baseServiceURL.toExternalForm());
+        return wt.getObservation();
+    }
+
+	@Override
+	public List<ObservationResponse> get(List<ObservationURI> listURI) throws InterruptedException, ExecutionException {
+        init();
+        if (listURI == null) {
+            throw new IllegalArgumentException("list of uri cannot be null");
+        }
+        //****************
+        List<ObservationResponse> list = new ArrayList<>();
+        // Create tasks for each file
+        List<Callable<ObservationResponse>> tasks = new ArrayList<>();
+
+        // want to put the result list back in same order as the input list; 
+        // maxLasModifiedComparatorForResponse sorts by state.maxLastModified
+        // so fake it with date values that increase
+        Date now = new Date();
+        long i = 0;
+        Subject subjectForWorkerThread = AuthenticationUtil.getCurrentSubject();
+        for (ObservationURI uri : listURI) {
+            ObservationState os = new ObservationState(uri);
+            os.maxLastModified = new Date(now.getTime() + i++);
+            tasks.add(new Worker(os, subjectForWorkerThread, baseServiceURL.toExternalForm()));
+        }
+        ExecutorService taskExecutor = null;
+        try {
+            // Run tasks in a fixed thread pool
+            taskExecutor = Executors.newFixedThreadPool(nthreads);
+            List<Future<ObservationResponse>> futures;
+
+            futures = taskExecutor.invokeAll(tasks);
+
+            for (Future<ObservationResponse> f : futures) {
+                ObservationResponse res = null;
+                res = f.get();
+
+                if (f.isDone()) {
+                    list.add(res);
+                }
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Error when executing thread in ThreadPool: " + e.getMessage() + " caused by: " + e.getCause().toString());
+            throw e;
+        } finally {
+            if (taskExecutor != null) {
+                taskExecutor.shutdown();
+            }
+        }
+        Collections.sort(list, maxLasModifiedComparatorForResponse);
+
+        //****************
+        return list;
+    }
+
+	@Override
+    public ObservationResponse get(String collection, URI uri, Date start) {
+        if (uri == null) {
+            throw new IllegalArgumentException("uri cannot be null");
+        }
+
+        init();
+
+        log.debug("******************* getObservationList(collection, start, null, null) " + collection);
+
+        List<ObservationState> list = getObservationList(collection, start, null, null);
+        ObservationState obsState = null;
+        for (ObservationState os : list) {
+            if (!os.getURI().getURI().equals(uri)) {
+                continue;
+            }
+            obsState = os;
+            break;
+        }
+
+        log.debug("******************* getting to getList " + obsState);
+
+        if (obsState != null) {
+            // see comment above in getList
+            Subject subjectForWorkerThread = AuthenticationUtil.getCurrentSubject();
+            Worker wt = new Worker(obsState, subjectForWorkerThread, baseServiceURL.toExternalForm());
+            return wt.getObservation();
+        } else {
+            return null;
+        }
+    }
+
+    private List<ObservationState> transformByteArrayOutputStreamIntoListOfObservationState(final ByteArrayOutputStream bos, DateFormat sdf, char separator,
+            char endOfLine)
+
+            throws ParseException, IOException, URISyntaxException {
+        init();
+
+        List<ObservationState> list = new ArrayList<>();
+
+        String id = null;
+        String sdate;
+        Date date = null;
+        String collection = null;
+        String md5;
+        String aux = "";
+
+        boolean readingDate = false;
+        boolean readingCollection = true;
+        boolean readingId = false;
+
+        for (int i = 0; i < bos.toString().length(); i++) {
+            char c = bos.toString().charAt(i);
+
+            if (c != ' ' && c != separator && c != endOfLine) {
+                aux += c;
+            } else if (c == separator) {
+                if (readingCollection) {
+                    collection = aux;
+                    // log.debug("*************** collection: " + collection);
+                    readingCollection = false;
+                    readingId = true;
+                    readingDate = false;
+                    aux = "";
+                } else if (readingId) {
+                    id = aux;
+                    // log.debug("*************** id: " + id);
+                    readingCollection = false;
+                    readingId = false;
+                    readingDate = true;
+                    aux = "";
+                } else if (readingDate) {
+                    sdate = aux;
+                    // log.debug("*************** sdate: " + sdate);
+                    date = DateUtil.flexToDate(sdate, sdf);
+
+                    readingCollection = false;
+                    readingId = false;
+                    readingDate = false;
+                    aux = "";
+                }
+
+            } else if (c == ' ') {
+                if (readingDate) {
+                    sdate = aux;
+                    // log.debug("*************** sdate: " + sdate);
+                    date = DateUtil.flexToDate(sdate, sdf);
+
+                    readingCollection = false;
+                    readingId = false;
+                    readingDate = false;
+                    aux = "";
+                }
+            } else if (c == endOfLine) {
+                if (id == null || collection == null) {
+                    continue;
+                }
+
+                ObservationState os = new ObservationState(new ObservationURI(collection, id));
+
+                if (date == null) {
+                    sdate = aux;
+                    date = DateUtil.flexToDate(sdate, sdf);
+                }
+
+                os.maxLastModified = date;
+
+                md5 = aux;
+                aux = "";
+                // log.debug("*************** md5: " + md5);
+                if (!md5.equals("")) {
+                    os.accMetaChecksum = new URI(md5);
+                }
+
+                // if (os.maxLastModified == null)
+                // {
+                // log.debug("*************** NO DATE");
+                // System.exit(1);
+                // }
+                list.add(os);
+                readingCollection = true;
+                readingId = false;
+            }
+        }
+        Collections.sort(list, maxLasModifiedComparatorForState);
+        return list;
+
+    }
+
+	@Override
+	public URI getResourceID() {
+		return resourceID;
+	}
+
+	@Override
+	public int getNthreads() {
+		return nthreads;
+	}
+
+	@Override
+	public URL getBaseServiceURL() {
+		return baseServiceURL;
+	}
+
+	@Override
+	public void setBaseServiceURL(URL baseServiceURL) {
+		this.baseServiceURL=baseServiceURL;
+	}
+
+	@Override
+	public URL getBaseDeletionURL() {
+		return baseDeletionURL;
+	}
+
+	@Override
+	public void setBaseDeletionURL(URL baseDeletionURL) {
+		this.baseDeletionURL=baseDeletionURL;
+	}
+    
+}

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/HttpRepoClient.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/HttpRepoClient.java
@@ -1,71 +1,71 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2011.                            (c) 2011.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2011.                            (c) 2011.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.caom2.repo.client;
 
@@ -74,7 +74,7 @@ import java.net.URL;
 
 import org.apache.log4j.Logger;
 
-public class HttpRepoClient extends AbstractRepoClient{
+public class HttpRepoClient extends AbstractRepoClient {
 
     private static final Logger log = Logger.getLogger(HttpRepoClient.class);
 
@@ -86,8 +86,8 @@ public class HttpRepoClient extends AbstractRepoClient{
      * @param nthreads
      *            number of threads to use when getting list of observations
      */
-    public HttpRepoClient(URI resourceID, int nthreads, URL baseServiceURL, URL baseDeletionURL ) {
-    	super(resourceID, nthreads);
+    public HttpRepoClient(URI resourceID, int nthreads, URL baseServiceURL, URL baseDeletionURL) {
+        super(resourceID, nthreads);
         setBaseServiceURL(baseServiceURL);
         setBaseDeletionURL(baseDeletionURL);
     }

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/HttpRepoClient.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/HttpRepoClient.java
@@ -69,43 +69,41 @@
 
 package ca.nrc.cadc.caom2.repo.client;
 
-import ca.nrc.cadc.caom2.DeletedObservation;
-import ca.nrc.cadc.caom2.ObservationResponse;
-import ca.nrc.cadc.caom2.ObservationState;
-import ca.nrc.cadc.caom2.ObservationURI;
-
 import java.net.URI;
 import java.net.URL;
-import java.security.AccessControlException;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 
-public interface RepoClient {
-	
-    public List<DeletedObservation> getDeleted(String collection, Date start, Date end, Integer maxrec);
+import org.apache.log4j.Logger;
 
-    public List<ObservationState> getObservationList(String collection, Date start, Date end, Integer maxrec) throws AccessControlException;
+public class HttpRepoClient extends AbstractRepoClient{
 
-    public List<ObservationResponse> getList(String collection, Date startDate, Date end, Integer numberOfObservations)
-            throws InterruptedException, ExecutionException;
+    private static final Logger log = Logger.getLogger(HttpRepoClient.class);
 
-    public List<ObservationResponse> get(List<ObservationURI> listURI) throws InterruptedException, ExecutionException;
-    
-    public ObservationResponse get(ObservationURI uri);
+    /**
+     * Create new CAOM RepoClient.
+     *
+     * @param resourceID
+     *            the service identifier
+     * @param nthreads
+     *            number of threads to use when getting list of observations
+     */
+    public HttpRepoClient(URI resourceID, int nthreads, URL baseServiceURL, URL baseDeletionURL ) {
+    	super(resourceID, nthreads);
+        setBaseServiceURL(baseServiceURL);
+        setBaseDeletionURL(baseDeletionURL);
+    }
 
-    public ObservationResponse get(String collection, URI uri, Date start);
-    
-	public URI getResourceID();
+    protected void init() {
+        if (getBaseServiceURL() == null) {
+            throw new RuntimeException("observation list URL not defined");
+        }
+        log.debug("observation list URL: " + getBaseServiceURL().toString());
+    }
 
-	public int getNthreads();
-
-	public URL getBaseServiceURL();
-
-	public void setBaseServiceURL(URL baseServiceURL);
-
-	public URL getBaseDeletionURL();
-
-	public void setBaseDeletionURL(URL baseDeletionURL);
+    protected void initDel() {
+        if (getBaseDeletionURL() == null) {
+            throw new RuntimeException("deletion list URL not defined");
+        }
+        log.debug("deletion list URL: " + getBaseDeletionURL().toString());
+    }
 
 }

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/Main.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/Main.java
@@ -1,69 +1,69 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2017.                            (c) 2017.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2017.                            (c) 2017.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.caom2.repo.client;
 
@@ -107,24 +107,27 @@ public class Main {
                 usage();
                 System.exit(0);
             }
-            //            Subject subject = AuthenticationUtil.getAnonSubject();
-            //            if (am.isSet("netrc")) {
-            //                subject = AuthenticationUtil.getSubject(new NetrcAuthenticator(true));
-            //            } else if (am.isSet("cert")) {
-            //                subject = CertCmdArgUtil.initSubject(am);
-            //            }
-            //            AuthMethod meth = AuthenticationUtil.getAuthMethodFromCredentials(subject);
-            //            log.info("authentication using: " + meth);
+            // Subject subject = AuthenticationUtil.getAnonSubject();
+            // if (am.isSet("netrc")) {
+            // subject = AuthenticationUtil.getSubject(new
+            // NetrcAuthenticator(true));
+            // } else if (am.isSet("cert")) {
+            // subject = CertCmdArgUtil.initSubject(am);
+            // }
+            // AuthMethod meth =
+            // AuthenticationUtil.getAuthMethodFromCredentials(subject);
+            // log.info("authentication using: " + meth);
             //
-            //            log.info("AuthenticationUtil.getCurrentSubject(): " + AuthenticationUtil.getCurrentSubject());
+            // log.info("AuthenticationUtil.getCurrentSubject(): " +
+            // AuthenticationUtil.getCurrentSubject());
 
             RepoClient rc = new RegisteredRepoClient(new URI("ivo://cadc.nrc.ca/caom2repo"), 1);
 
             List<DeletedObservation> list = rc.getDeleted("HSTHLA", null, null, 100);
 
-            //            for (DeletedObservation deleted : list) {
-            //                log.info(deleted.getURI().getObservationID());
-            //            }
+            // for (DeletedObservation deleted : list) {
+            // log.info(deleted.getURI().getObservationID());
+            // }
         } catch (Throwable uncaught) {
             log.error("uncaught exception", uncaught);
             System.exit(-1);

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/Main.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/Main.java
@@ -118,7 +118,7 @@ public class Main {
             //
             //            log.info("AuthenticationUtil.getCurrentSubject(): " + AuthenticationUtil.getCurrentSubject());
 
-            RepoClient rc = new RepoClient(new URI("ivo://cadc.nrc.ca/caom2repo"), 1);
+            RepoClient rc = new RegisteredRepoClient(new URI("ivo://cadc.nrc.ca/caom2repo"), 1);
 
             List<DeletedObservation> list = rc.getDeleted("HSTHLA", null, null, 100);
 

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/RegisteredRepoClient.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/RegisteredRepoClient.java
@@ -1,71 +1,71 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2011.                            (c) 2011.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2011.                            (c) 2011.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.caom2.repo.client;
 
@@ -81,7 +81,7 @@ import javax.security.auth.Subject;
 
 import org.apache.log4j.Logger;
 
-public class RegisteredRepoClient extends AbstractRepoClient{
+public class RegisteredRepoClient extends AbstractRepoClient {
 
     private static final Logger log = Logger.getLogger(RegisteredRepoClient.class);
 
@@ -96,8 +96,8 @@ public class RegisteredRepoClient extends AbstractRepoClient{
      *            number of threads to use when getting list of observations
      */
     public RegisteredRepoClient(URI resourceID, int nthreads) {
-    	super(resourceID, nthreads);
-    	this.rc = new RegistryClient();
+        super(resourceID, nthreads);
+        this.rc = new RegistryClient();
     }
 
     protected void init() {

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/RepoClient.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/RepoClient.java
@@ -1,71 +1,71 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2011.                            (c) 2011.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2011.                            (c) 2011.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.caom2.repo.client;
 
@@ -82,30 +82,30 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 public interface RepoClient {
-	
+
     public List<DeletedObservation> getDeleted(String collection, Date start, Date end, Integer maxrec);
 
     public List<ObservationState> getObservationList(String collection, Date start, Date end, Integer maxrec) throws AccessControlException;
 
-    public List<ObservationResponse> getList(String collection, Date startDate, Date end, Integer numberOfObservations)
-            throws InterruptedException, ExecutionException;
+    public List<ObservationResponse> getList(String collection, Date startDate, Date end, Integer numberOfObservations) throws InterruptedException,
+            ExecutionException;
 
     public List<ObservationResponse> get(List<ObservationURI> listURI) throws InterruptedException, ExecutionException;
-    
+
     public ObservationResponse get(ObservationURI uri);
 
     public ObservationResponse get(String collection, URI uri, Date start);
-    
-	public URI getResourceID();
 
-	public int getNthreads();
+    public URI getResourceID();
 
-	public URL getBaseServiceURL();
+    public int getNthreads();
 
-	public void setBaseServiceURL(URL baseServiceURL);
+    public URL getBaseServiceURL();
 
-	public URL getBaseDeletionURL();
+    public void setBaseServiceURL(URL baseServiceURL);
 
-	public void setBaseDeletionURL(URL baseDeletionURL);
+    public URL getBaseDeletionURL();
+
+    public void setBaseDeletionURL(URL baseDeletionURL);
 
 }

--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.13'
+version = '2.3.14'
 
 mainClassName = 'ca.nrc.cadc.caom2.harvester.Main'
 
@@ -30,7 +30,7 @@ dependencies {
     compile 'org.opencadc:caom2-compute:[2.3.6,)'
     compile 'org.opencadc:caom2persistence:[2.3.15,)'
     compile 'org.opencadc:cadc-util:[1.0.14,)'
-    compile 'org.opencadc:caom2-repo:[1.1,)'
+    compile 'org.opencadc:caom2-repo:[1.2,)'
     compile 'org.opencadc:caom2-persist:[2.3.3,)'
 
     runtime 'net.sourceforge.jtds:jtds:1.+'

--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile 'org.opencadc:caom2-compute:[2.3.6,)'
     compile 'org.opencadc:caom2persistence:[2.3.15,)'
     compile 'org.opencadc:cadc-util:[1.0.14,)'
-    compile 'org.opencadc:caom2-repo:[1.2,)'
+    compile 'org.opencadc:caom2-repo:[1.3,)'
     compile 'org.opencadc:caom2-persist:[2.3.3,)'
 
     runtime 'net.sourceforge.jtds:jtds:1.+'

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/DeletionHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/DeletionHarvester.java
@@ -163,7 +163,7 @@ public class DeletionHarvester extends Harvester implements Runnable {
             this.deletedDAO = new DeletedEntityDAO();
             deletedDAO.setConfig(config1);
         } else {
-            this.repoClient = new RepoClient(src.getResourceID(), 1);
+            this.repoClient = RepoClientFactory.getRepoClient(src, 1);
         }
         
         // destination

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -109,7 +109,7 @@ public class Main {
 
             if (am.isSet("d") || am.isSet("debug")) {
                 Log4jInit.setLevel("ca.nrc.cadc.caom.harvester", Level.DEBUG);
-                //Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.DEBUG);
+                // Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.DEBUG);
                 Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client", Level.DEBUG);
                 Log4jInit.setLevel("ca.nrc.cadc.reg.client", Level.DEBUG);
             } else if (am.isSet("v") || am.isSet("verbose")) {
@@ -184,7 +184,7 @@ public class Main {
 
             boolean nosrc = (source == null || source.trim().length() == 0);
             boolean nosrv = (resourceID == null || resourceID.trim().length() == 0);
-            boolean nourls = ( obsBaseUrl == null || obsBaseUrl.trim().length() == 0 || delBaseUrl == null || delBaseUrl.trim().length() == 0 );
+            boolean nourls = (obsBaseUrl == null || obsBaseUrl.trim().length() == 0 || delBaseUrl == null || delBaseUrl.trim().length() == 0);
             if (nosrc && nosrv && nourls) {
                 log.warn("missing required argument: --source=<server.database.schema> | --resourceID=<identifier> | --obsBaseUrl=<URL> --delBaseUrl=<URL>");
                 usage();
@@ -195,9 +195,9 @@ public class Main {
             int nthreads = 1;
             if (resourceID != null) {
                 try {
-                    if(obsBaseUrl !=null && delBaseUrl!=null){
+                    if (obsBaseUrl != null && delBaseUrl != null) {
                         src = new HarvestResource(new URI(resourceID), new URL(obsBaseUrl), new URL(delBaseUrl), collection);
-                    }else{
+                    } else {
                         src = new HarvestResource(new URI(resourceID), collection);
                     }
                     if (am.isSet("threads")) {
@@ -329,9 +329,10 @@ public class Main {
 
                 try {
                     CaomValidator cv = new CaomValidator(dryrun, noChecksum, src, dest, batchSize);
-                    // [min,max] timestamps not supported by validator (only full)
-                    //cv.setMinDate(minDate);
-                    //cv.setMaxDate(maxDate);
+                    // [min,max] timestamps not supported by validator (only
+                    // full)
+                    // cv.setMinDate(minDate);
+                    // cv.setMaxDate(maxDate);
                     action = cv;
                 } catch (IOException ioex) {
 
@@ -379,7 +380,8 @@ public class Main {
         sb.append("\n         --basePublisherID=ivo://<authority>[/<path>] : base for generating Plane publisherID values");
         sb.append("\n                      publisherID values: <basePublisherID>/<collection>?<observationID>/<productID>");
 
-        sb.append("\n\nSource selection: --resourceID=<URI> [--threads=<num threads>] | --source=<server.database.schema> | --obsBaseUrl=<URL> --delBaseUrl=<URL> [--threads=<num threads>]");
+        sb.append("\n\nSource selection: --resourceID=<URI> [--threads=<num threads>] | --source=<server.database.schema> "
+                + "\n\n                  | --obsBaseUrl=<URL> --delBaseUrl=<URL> [--threads=<num threads>]");
         sb.append("\n         --resourceID : harvest from a caom2 repository service (e.g. ivo://cadc.nrc.ca/caom2repo)");
         sb.append("\n         --obsBaseUrl : Specific Observations service base URL (e.g. https://masttest.stsci.edu/partners/meta-service/obs-endpoint)");
         sb.append("\n         --delBaseUrl : Specific Deletion service base URL (e.g. https://masttest.stsci.edu/partners/meta-service/del-endpoint)");

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -80,6 +80,7 @@ import ca.nrc.cadc.util.Log4jInit;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
@@ -175,11 +176,14 @@ public class Main {
             // source can be a database or service
             String source = am.getValue("source");
             String resourceID = am.getValue("resourceID");
+            String obsBaseUrl = am.getValue("obsBaseUrl");
+            String delBaseUrl = am.getValue("delBaseUrl");
 
             boolean nosrc = (source == null || source.trim().length() == 0);
             boolean nosrv = (resourceID == null || resourceID.trim().length() == 0);
-            if (nosrc && nosrv) {
-                log.warn("missing required argument: --source=<server.database.schema> | --resourceID=<identifier>");
+            boolean nourls = ( obsBaseUrl == null || obsBaseUrl.trim().length() == 0 || delBaseUrl == null || delBaseUrl.trim().length() == 0 );
+            if (nosrc && nosrv && nourls) {
+                log.warn("missing required argument: --source=<server.database.schema> | --resourceID=<identifier> | --obsBaseUrl=<URL> --delBaseUrl=<URL>");
                 usage();
                 System.exit(1);
             }
@@ -188,7 +192,11 @@ public class Main {
             int nthreads = 1;
             if (resourceID != null) {
                 try {
-                    src = new HarvestResource(new URI(resourceID), collection);
+                    if(obsBaseUrl !=null && delBaseUrl!=null){
+                        src = new HarvestResource(new URI(resourceID), new URL(obsBaseUrl), new URL(delBaseUrl), collection);
+                    }else{
+                        src = new HarvestResource(new URI(resourceID), collection);
+                    }
                     if (am.isSet("threads")) {
                         nthreads = Integer.parseInt(am.getValue("threads"));
                     }
@@ -370,8 +378,10 @@ public class Main {
         sb.append("\n         --basePublisherID=ivo://<authority>[/<path>] : base for generating Plane publisherID values");
         sb.append("\n                      publisherID values: <basePublisherID>/<collection>?<observationID>/<productID>");
 
-        sb.append("\n\nSource selection: --resourceID=<URI> [--threads=<num threads>] | --source=<server.database.schema>");
+        sb.append("\n\nSource selection: --resourceID=<URI> [--threads=<num threads>] | --source=<server.database.schema> | --obsBaseUrl=<URL> --delBaseUrl=<URL> [--threads=<num threads>]");
         sb.append("\n         --resourceID : harvest from a caom2 repository service (e.g. ivo://cadc.nrc.ca/caom2repo)");
+        sb.append("\n         --obsBaseUrl : Specific Observations service base URL (e.g. https://masttest.stsci.edu/partners/meta-service/obs-endpoint)");
+        sb.append("\n         --delBaseUrl : Specific Deletion service base URL (e.g. https://masttest.stsci.edu/partners/meta-service/del-endpoint)");
         sb.append("\n         --threads : number  of threads used to read observation documents (default: 1)");
         sb.append("\n         --source : harvest directly from a database server");
 

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
@@ -157,7 +157,7 @@ public class ObservationHarvester extends Harvester {
             this.srcObservationDAO = new ObservationDAO();
             srcObservationDAO.setConfig(config1);
         } else {
-            this.srcObservationService = new RepoClient(src.getResourceID(), nthreads);
+            this.srcObservationService = RepoClientFactory.getRepoClient(src, nthreads);
         }
 
         // for now, dest is always a database

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
@@ -120,7 +120,7 @@ public class ObservationValidator extends Harvester {
     private void init() throws IOException, URISyntaxException {
         if (src.getResourceID() != null) {
             // 1 thread since we only use the ObservationState listing
-            this.srcObservationService = new RepoClient(src.getResourceID(), 1);
+            this.srcObservationService = RepoClientFactory.getRepoClient(src, 1);
         } else {
             Map<String, Object> config1 = getConfigDAO(src);
             this.srcObservationDAO = new ObservationDAO();

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/RepoClientFactory.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/RepoClientFactory.java
@@ -66,10 +66,8 @@
  *
  ************************************************************************
  */
-package ca.nrc.cadc.caom2.harvester;
 
-import java.net.URI;
-import java.net.URISyntaxException;
+package ca.nrc.cadc.caom2.harvester;
 
 import ca.nrc.cadc.caom2.repo.client.HttpRepoClient;
 import ca.nrc.cadc.caom2.repo.client.RegisteredRepoClient;
@@ -82,14 +80,11 @@ import ca.nrc.cadc.caom2.repo.client.RepoClient;
 public class RepoClientFactory {
     public static RepoClient getRepoClient(HarvestResource src, int nthreads) {
 
-        if (src.getObsBaseUrl()!=null && src.getDelBaseUrl()!=null) {
+        if (src.getObsBaseUrl() != null && src.getDelBaseUrl() != null) {
             return new HttpRepoClient(src.getResourceID(), nthreads, src.getObsBaseUrl(), src.getDelBaseUrl());
-        }else {
-            return new RegisteredRepoClient( src.getResourceID(), nthreads);
+        } else {
+            return new RegisteredRepoClient(src.getResourceID(), nthreads);
         }
 
     }
 }
-
-
-

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/RepoClientFactory.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/RepoClientFactory.java
@@ -62,143 +62,34 @@
  *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
  *                                       <http://www.gnu.org/licenses/>.
  *
+ *  $Revision: 5 $
+ *
  ************************************************************************
  */
-
 package ca.nrc.cadc.caom2.harvester;
 
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 
-import org.apache.log4j.Logger;
+import ca.nrc.cadc.caom2.repo.client.HttpRepoClient;
+import ca.nrc.cadc.caom2.repo.client.RegisteredRepoClient;
+import ca.nrc.cadc.caom2.repo.client.RepoClient;
 
 /**
- * Encapsulate the information about a source or destination for harvesting
- * instances.
+ * @author Raul Gutierrez-Sanchez
  *
- * @author pdowler
  */
-public class HarvestResource {
+public class RepoClientFactory {
+    public static RepoClient getRepoClient(HarvestResource src, int nthreads) {
 
-    private static final Logger log = Logger.getLogger(HarvestResource.class);
-
-    private String databaseServer;
-    private String database;
-    private String schema;
-    private boolean harvestAC;
-
-    private URI resourceID;
-    private String collection;
-    
-    private URL obsBaseUrl;
-    private URL delBaseUrl;
-
-    /**
-     * Create a HarvestResource for a database. This is suitable for a
-     * destination and
-     * when intending to harvest access control tuples.
-     *
-     * @param databaseServer server name in $HOME/.dbrc
-     * @param database database name in $HOME/.dbrc and query generation
-     * @param schema schema name for query generation
-     * @param collection name of collection to harvest
-     */
-    public HarvestResource(String databaseServer, String database, String schema, String collection) {
-        this(databaseServer, database, schema, collection, true);
-    }
-
-    /**
-     * Create a HarvestResource for a database.
-     *
-     * @param databaseServer server name in $HOME/.dbrc
-     * @param database database name in $HOME/.dbrc and query generation
-     * @param schema schema name for query generation
-     * @param collection name of collection to harvest
-     * @param harvestAC true to enable harvesting access control tuples
-     */
-    public HarvestResource(String databaseServer, String database, String schema, String collection, boolean harvestAC) {
-        if (databaseServer == null || database == null || schema == null || collection == null) {
-            throw new IllegalArgumentException("args cannot be null");
+        if (src.getObsBaseUrl()!=null && src.getDelBaseUrl()!=null) {
+            return new HttpRepoClient(src.getResourceID(), nthreads, src.getObsBaseUrl(), src.getDelBaseUrl());
+        }else {
+            return new RegisteredRepoClient( src.getResourceID(), nthreads);
         }
-        this.databaseServer = databaseServer;
-        this.database = database;
-        this.schema = schema;
-        this.collection = collection;
-        this.harvestAC = harvestAC;
-    }
 
-    /**
-     * Create a HarvestResource from a URI
-     * @param resourceID
-     * @param collection
-     */
-    public HarvestResource(URI resourceID, String collection) {
-        if (resourceID == null || collection == null) {
-            throw new IllegalArgumentException("resourceID and collection args cannot be null");
-        }
-        this.resourceID = resourceID;
-        this.collection = collection;
-        this.harvestAC = true; // no API for this
     }
-
-    
-    
-    /**
-     * Create a HarvestResource given the Observation and Delete endpoints URLs
-     * @param resourceID
-     * @param collection
-     */
-    public HarvestResource(URI resourceID, URL obsBaseUrl, URL delBaseUrl, String collection) {
-        if (resourceID == null || obsBaseUrl == null || delBaseUrl == null || collection == null) {
-            throw new IllegalArgumentException("resourceID, obsBaseUrl, obsDelUrl and collection args cannot be null");
-        }
-        this.resourceID = resourceID;
-        this.obsBaseUrl = obsBaseUrl;
-        this.delBaseUrl = delBaseUrl;
-        this.collection = collection;
-        this.harvestAC = true; // no API for this
-    }
-    
-    
-    
-    public String getIdentifier() {
-        if (resourceID != null) {
-            return resourceID.toASCIIString() + "?" + collection;
-        }
-        return databaseServer + "." + database + "." + schema + "?" + collection;
-    }
-
-    public String getDatabaseServer() {
-        return databaseServer;
-    }
-
-    public String getDatabase() {
-        return database;
-    }
-
-    public String getSchema() {
-        return schema;
-    }
-
-    public boolean getHarvestAC() {
-        return harvestAC;
-    }
-
-    public URI getResourceID() {
-        return resourceID;
-    }
-
-    public String getCollection() {
-        return collection;
-    }
-
-    public URL getObsBaseUrl() {
-        return obsBaseUrl;
-    }
-
-    public URL getDelBaseUrl() {
-        return delBaseUrl;
-    }
-    
-    
 }
+
+
+


### PR DESCRIPTION
In order to allow the injection of a custom repository server (mainly for testing) RepoClient has been modified to include a new HttpRepoClient. Original RepoClient using the registry is now called RegisteredRepoClient. A new interface RepoClient has been created and an AbstractRepoClient class contains the common code.