### PR TITLE
re-implemented caom2-repo list parsing to avoid excessive string concatenation

### DIFF
--- a/caom2-persist/build.gradle
+++ b/caom2-persist/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.3'
+version = '2.3.4'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-persist/src/main/java/ca/nrc/cadc/caom2/DeletedEntity.java
+++ b/caom2-persist/src/main/java/ca/nrc/cadc/caom2/DeletedEntity.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2011.                            (c) 2011.
+*  (c) 2018.                            (c) 2018.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -78,7 +78,7 @@ import java.util.UUID;
 public class DeletedEntity {
     public Class entityClass;
     private final UUID id;
-    private Date lastModified;
+    public Date lastModified;
 
     DeletedEntity(Class entityClass, UUID id) {
         this.entityClass = entityClass;
@@ -89,6 +89,12 @@ public class DeletedEntity {
         return id;
     }
 
+    /**
+     * 
+     * @return
+     * @deprecated field is public
+     */
+    @Deprecated
     public Date getLastModified() {
         return lastModified;
     }

--- a/caom2-repo/build.gradle
+++ b/caom2-repo/build.gradle
@@ -27,8 +27,7 @@ dependencies {
     
     compile 'org.opencadc:cadc-util:[1.0.14,)'
     compile 'org.opencadc:caom2:[2.3.9,)'
-    compile 'org.opencadc:caom2-persist:[2.3.2,3.0)'
-    compile 'org.opencadc:caom2persistence:[2.3.14,)'
+    compile 'org.opencadc:caom2-persist:[2.3.4,3.0)'
 
     compile 'org.opencadc:cadc-registry:[1.2,)'
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/RepoClient.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/RepoClient.java
@@ -424,7 +424,7 @@ public class RepoClient {
 
                 if (partialList != null) {
                     accList.addAll(partialList);
-                    log.warn("adding " + partialList.size() + " elements to accList. Now there are " + accList.size());
+                    log.debug("adding " + partialList.size() + " elements to accList. Now there are " + accList.size());
                 }
 
                 bos.close();

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/transform/AbstractListReader.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/transform/AbstractListReader.java
@@ -70,10 +70,12 @@
 package ca.nrc.cadc.caom2.repo.client.transform;
 
 import ca.nrc.cadc.caom2.ObservationState;
-
-import java.io.ByteArrayOutputStream;
+import ca.nrc.cadc.date.DateUtil;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -86,12 +88,10 @@ import java.util.List;
  * @author jduran
  *
  */
-public abstract class AbstractListReader {
+public abstract class AbstractListReader<T> {
 
-    private DateFormat dateFormat = null;
-    private char separator = '0';
-    private char endOfLine = '0';
-
+    protected final DateFormat dateFormat = DateUtil.getDateFormat(DateUtil.IVOA_DATE_FORMAT, DateUtil.UTC);
+    
     private Comparator<ObservationState> maxLasModifiedComparator = new Comparator<ObservationState>() {
         @Override
         public int compare(ObservationState o1, ObservationState o2) {
@@ -99,31 +99,19 @@ public abstract class AbstractListReader {
         }
     };
 
-    public AbstractListReader(DateFormat dateFormat, char separator, char endOfLine) {
-        this.dateFormat = dateFormat;
-        this.separator = separator;
-        this.endOfLine = endOfLine;
-    }
-
-    public Comparator<ObservationState> getComparator() {
+    private Comparator<ObservationState> getComparator() {
         return maxLasModifiedComparator;
     }
 
-    public DateFormat getDateFormat() {
-        return dateFormat;
+    public List<T> read(InputStream in) throws ParseException, IOException, URISyntaxException {
+        InputStreamReader ir = new InputStreamReader(in);
+        return read(ir);
     }
 
-    public char getSeparator() {
-        return separator;
+    public List<T> read(String in) throws ParseException, IOException, URISyntaxException {
+        StringReader sr = new StringReader(in);
+        return read(sr);
     }
 
-    public char getEndOfLine() {
-        return endOfLine;
-    }
-
-    public abstract List read(ByteArrayOutputStream bos) throws ParseException, IOException, URISyntaxException;
-
-    public abstract List read(String in);
-
-    public abstract List read(Reader in);
+    public abstract List<T> read(Reader in) throws ParseException, IOException, URISyntaxException;
 }

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/transform/DeletionListReader.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/transform/DeletionListReader.java
@@ -106,19 +106,22 @@ public class DeletionListReader extends AbstractListReader<DeletedObservation> {
         String line = reader.readLine();
         while (line != null) {
             try {
-                // <Observation.id> <Observation.collection> <Observation.observationID> <deletion timestamp>
-                String[] tokens = line.split("\\s+"); // ICD says tabs but be generous and split of any whitespace
-                String sid = tokens[0];
-                UUID uuid = UUID.fromString(sid);
-                String collection = tokens[1];
-                String observationID = tokens[2];
-                ObservationURI uri = new ObservationURI(collection, observationID);
-                DeletedObservation dd = new DeletedObservation(uuid, uri);
-                // 
-                if (tokens.length > 3 && tokens[3].length() > 0) {
-                    dd.lastModified = DateUtil.flexToDate(tokens[3], dateFormat);
+                line = line.trim();
+                if (!line.isEmpty()) {
+                    // <Observation.id> <Observation.collection> <Observation.observationID> <deletion timestamp>
+                    String[] tokens = line.split("\\s+"); // ICD says tabs but be generous and split of any whitespace
+                    String sid = tokens[0];
+                    UUID uuid = UUID.fromString(sid);
+                    String collection = tokens[1];
+                    String observationID = tokens[2];
+                    ObservationURI uri = new ObservationURI(collection, observationID);
+                    DeletedObservation dd = new DeletedObservation(uuid, uri);
+                    // 
+                    if (tokens.length > 3 && tokens[3].length() > 0) {
+                        dd.lastModified = DateUtil.flexToDate(tokens[3], dateFormat);
+                    }
+                    ret.add(dd);
                 }
-                ret.add(dd);
                 
                 line = reader.readLine();
             } finally {

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/transform/DeletionListReader.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/transform/DeletionListReader.java
@@ -71,20 +71,16 @@ package ca.nrc.cadc.caom2.repo.client.transform;
 
 import ca.nrc.cadc.caom2.DeletedObservation;
 import ca.nrc.cadc.caom2.ObservationURI;
-import ca.nrc.cadc.caom2.persistence.Util;
 import ca.nrc.cadc.date.DateUtil;
-
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.LineNumberReader;
 import java.io.Reader;
 import java.net.URISyntaxException;
-import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-
 import org.apache.log4j.Logger;
 
 /**
@@ -93,111 +89,46 @@ import org.apache.log4j.Logger;
  * @author jduran
  *
  */
-public class DeletionListReader extends AbstractListReader {
+public class DeletionListReader extends AbstractListReader<DeletedObservation> {
 
     private static final Logger log = Logger.getLogger(DeletionListReader.class);
 
-    public DeletionListReader(DateFormat dateFormat, char separator, char endOfLine) {
-        super(dateFormat, separator, endOfLine);
+    public DeletionListReader() {
+        super();
     }
 
+    
+
     @Override
-    public List read(ByteArrayOutputStream bos) throws ParseException, IOException, URISyntaxException {
-        // <Observation.id> <Observation.collection> <Observation.observationID> <timestamp>
-        List<DeletedObservation> list = new ArrayList<>();
-
-        String id = null;
-        String observationID = null;
-        String sdate;
-        Date date = null;
-        String collection = null;
-
-        String aux = "";
-
-        boolean readingDate = false;
-        boolean readingCollection = false;
-        boolean readingId = false;
-        boolean readingObservationID = true;
-
-        for (int i = 0; i < bos.toString().length(); i++) {
-            char c = bos.toString().charAt(i);
-
-            if (c != getSeparator() && c != getEndOfLine()) {
-                aux += c;
-            } else if (c == getSeparator()) {
-                if (readingObservationID) {
-                    readingObservationID = false;
-                    readingCollection = true;
-                    readingId = false;
-                    readingDate = false;
-                    observationID = aux;
-                    aux = "";
-                } else if (readingCollection) {
-                    collection = aux;
-                    // log.debug("*************** collection: " + collection);
-                    readingObservationID = false;
-                    readingCollection = false;
-                    readingId = true;
-                    readingDate = false;
-                    aux = "";
-                } else if (readingId) {
-                    id = aux;
-                    // log.debug("*************** id: " + id);
-                    readingObservationID = false;
-                    readingCollection = false;
-                    readingId = false;
-                    readingDate = true;
-                    aux = "";
-                } else if (readingDate) {
-                    sdate = aux;
-                    // log.debug("*************** sdate: " + sdate);
-                    date = DateUtil.flexToDate(sdate, getDateFormat());
-                    readingObservationID = false;
-                    readingCollection = false;
-                    readingId = false;
-                    readingDate = false;
-                    aux = "";
+    public List<DeletedObservation> read(Reader in) throws ParseException, IOException, URISyntaxException {
+        final List<DeletedObservation> ret = new ArrayList<>(1000);
+        LineNumberReader reader = new LineNumberReader(in, 16384);
+        String line = reader.readLine();
+        while (line != null) {
+            try {
+                // <Observation.id> <Observation.collection> <Observation.observationID> <deletion timestamp>
+                String[] tokens = line.split("\\s+"); // ICD says tabs but be generous and split of any whitespace
+                String sid = tokens[0];
+                UUID uuid = UUID.fromString(sid);
+                String collection = tokens[1];
+                String observationID = tokens[2];
+                ObservationURI uri = new ObservationURI(collection, observationID);
+                DeletedObservation dd = new DeletedObservation(uuid, uri);
+                // 
+                if (tokens.length > 3 && tokens[3].length() > 0) {
+                    dd.lastModified = DateUtil.flexToDate(tokens[3], dateFormat);
                 }
-
-            } else if (c == getEndOfLine()) {
-                if (id == null || collection == null) {
-                    continue;
+                ret.add(dd);
+                
+                line = reader.readLine();
+            } finally {
+                if (reader.getLineNumber() % 100 == 0) {
+                    log.debug("read: line " + reader.getLineNumber());
                 }
-
-                sdate = aux;
-                date = DateUtil.flexToDate(sdate, getDateFormat());
-
-                // TODO: make call(s) to the deletion endpoint until requested number of entries (like getObservationList)
-
-                // parse each line into the following 4 values, create DeletedObservation, and add to output list, eg:
-
-                aux = "";
-
-                if (id != null && observationID != null && collection != null && date != null) {
-                    UUID uuid = UUID.fromString(observationID);
-                    ObservationURI uri = new ObservationURI(collection, id);
-                    DeletedObservation de = new DeletedObservation(uuid, uri);
-                    Util.assignDeletedLastModified(de, date, "lastModified");
-                    list.add(de);
-                }
-                readingCollection = false;
-                readingId = false;
-                readingObservationID = true;
-                readingDate = false;
             }
         }
-
-        return list;
-
+        return ret;
     }
-
-    @Override
-    public List read(String in) {
-        return null;
-    }
-
-    @Override
-    public List read(Reader in) {
-        return null;
-    }
+    
+    
 }

--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -16,9 +16,10 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.13'
+version = '2.3.14'
 
 mainClassName = 'ca.nrc.cadc.caom2.harvester.Main'
+applicationDefaultJvmArgs = ['-Xms1024m','-Xmx4096m','-XX:OnOutOfMemoryError="kill -3 %p"']
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -107,18 +107,16 @@ public class Main {
             ArgumentMap am = new ArgumentMap(args);
 
             if (am.isSet("d") || am.isSet("debug")) {
-                Log4jInit.setLevel("ca.nrc.cadc.caom.harvester", Level.DEBUG);
+                Log4jInit.setLevel("ca.nrc.cadc.caom2.harvester", Level.DEBUG);
                 //Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.DEBUG);
                 Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client", Level.DEBUG);
                 Log4jInit.setLevel("ca.nrc.cadc.reg.client", Level.DEBUG);
             } else if (am.isSet("v") || am.isSet("verbose")) {
-                Log4jInit.setLevel("ca.nrc.cadc.caom.harvester", Level.INFO);
-                Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.INFO);
+                Log4jInit.setLevel("ca.nrc.cadc.caom2.harvester", Level.INFO);
+                //Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.INFO);
                 Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client", Level.INFO);
             } else {
                 Log4jInit.setLevel("ca.nrc.cadc", Level.WARN);
-                Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client", Level.WARN);
-
             }
 
             if (am.isSet("h") || am.isSet("help")) {

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
@@ -390,6 +390,10 @@ public class ObservationHarvester extends Harvester {
                                 harvestSkipDAO.delete(hs);
                             }
                         } else if (skipped && ow.entity == null) {
+                            // observation was simply missing from source == missed deletion
+                            ObservationURI uri = new ObservationURI(hs.getSkipID());
+                            log.info("delete: " + uri);
+                            destObservationDAO.delete(uri);
                             log.info("delete: " + hs + " " + format(hs.getLastModified()));
                             harvestSkipDAO.delete(hs);
                         } else if (ow.entity.error != null) {
@@ -509,11 +513,12 @@ public class ObservationHarvester extends Harvester {
                             harvestSkipDAO.put(skip);
 
                             // delete previous version of observation (if any)
+                            log.info("delete: " + ow.entity.observationState.getURI());
                             destObservationDAO.delete(ow.entity.observationState.getURI());
 
                             log.debug("committing HarvestSkipURI transaction");
                             destObservationDAO.getTransactionManager().commitTransaction();
-                            log.warn("commit HarvestSkipURI: OK");
+                            log.debug("commit HarvestSkipURI: OK");
                         } catch (Throwable oops) {
                             log.warn("failed to insert HarvestSkipURI", oops);
                             destObservationDAO.getTransactionManager().rollbackTransaction();

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationStateError.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationStateError.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2017.                            (c) 2017.
+ *  (c) 2018.                            (c) 2018.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -91,9 +91,9 @@ public class ObservationStateError implements Comparable<ObservationStateError> 
 
     @Override
     public String toString() {
-        String res = "";
+        String res = error;
         if (obs != null) {
-            res = obs.getURI().getURI() + ": " + error;
+            res += " : " + obs;
         }
         return res;
     }

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2017.                            (c) 2017.
+ *  (c) 2018.                            (c) 2018.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -177,8 +177,7 @@ public class ObservationValidator extends Harvester {
             List<ObservationState> tmpSrcState = null;
             List<ObservationState> tmpDstState = null;
 
-            tmpDstState = destObservationDAO.getObservationList(src.getCollection(), null, null, null);
-
+            log.info("getObservationList: " + src.getIdentifier());
             if (srcObservationDAO != null) {
                 tmpSrcState = srcObservationDAO.getObservationList(src.getCollection(), null, null, null);
             } else if (srcObservationService != null) {
@@ -186,17 +185,25 @@ public class ObservationValidator extends Harvester {
             } else {
                 throw new RuntimeException("BUG: both srcObservationDAO and srcObservationService are null");
             }
-
+            log.info("found: " + tmpSrcState.size());
+            
             Set<ObservationState> srcState = new TreeSet<>(compStateUri);
             srcState.addAll(tmpSrcState);
-            tmpSrcState.clear();
+            tmpSrcState = null; // GC
+            log.info("source set: " + srcState.size());
+            
+            log.info("getObservationList: " + dest.getIdentifier());
+            tmpDstState = destObservationDAO.getObservationList(dest.getCollection(), null, null, null);
+            log.info("found: " + tmpDstState.size());
+            
             Set<ObservationState> dstState = new TreeSet<>(compStateUri);
             dstState.addAll(tmpDstState);
-            tmpDstState.clear();
+            tmpDstState = null; // GC
+            log.info("destination set: " + dstState.size());
 
             Set<ObservationStateError> errlist = calculateErroneousObservationStates(srcState, dstState);
 
-            log.debug("************************** errlist.size() = " + errlist.size());
+            log.info("discrepancies found: " + errlist.size());
 
             timeQuery = System.currentTimeMillis() - t;
             t = System.currentTimeMillis();
@@ -204,7 +211,6 @@ public class ObservationValidator extends Harvester {
             List<SkippedWrapperURI<ObservationStateError>> entityListSrc = wrap(errlist);
 
             ret.found = srcState.size();
-            log.info("found: " + srcState.size());
 
             ListIterator<SkippedWrapperURI<ObservationStateError>> iter = entityListSrc.listIterator();
             while (iter.hasNext()) {
@@ -215,24 +221,18 @@ public class ObservationValidator extends Harvester {
                 String skipMsg = null;
 
                 try {
-                    // o could be null in skip mode cleanup
                     if (!dryrun) {
                         if (o != null) {
-                            skipMsg = o.toString();// + ": " + o.getError();
+                            skipMsg = o.toString();
                             try {
                                 log.debug("starting HarvestSkipURI transaction");
                                 boolean putSkip = true;
                                 HarvestSkipURI skip = harvestSkip.get(source, cname, o.getObs().getURI().getURI());
-                                Date tryAfter = new Date(); // TODO: could implement retry delaying/ordering/priority here
+                                Date tryAfter = o.getObs().maxLastModified;
                                 if (skip == null) {
                                     skip = new HarvestSkipURI(source, cname, o.getObs().getURI().getURI(), tryAfter, skipMsg);
-                                } else if (skipMsg != null && !skipMsg.equals(skip.errorMessage)) {
-                                    skip.setTryAfter(tryAfter);
-                                    skip.errorMessage = skipMsg; // possible
-                                    // update
                                 } else {
                                     putSkip = false; // avoid lastModified update for no change
-                                    // update
                                 }
 
                                 if (destObservationDAO.getTransactionManager().isOpen()) {
@@ -245,8 +245,9 @@ public class ObservationValidator extends Harvester {
                                 if (putSkip) {
                                     log.info("put: " + skip);
                                     harvestSkip.put(skip);
+                                } else {
+                                    log.info("known: " + skip);
                                 }
-
                             } catch (Throwable oops) {
                                 log.warn("failed to insert HarvestSkipURI", oops);
                                 destObservationDAO.getTransactionManager().rollbackTransaction();
@@ -328,7 +329,10 @@ public class ObservationValidator extends Harvester {
                 if (!listErroneous.contains(ose)) {
                     listErroneous.add(ose);
                 }
-            } else if (!nochecksum && !listCorrect.contains(os)) {
+            } 
+        }
+        /*
+          else if (!nochecksum && !listCorrect.contains(os)) {
                 ObservationStateError ose = new ObservationStateError(os, "computation or serialization bug");
                 log.info("************************ adding computation or serialization bug: " + os.getURI());
                 if (!listErroneous.contains(ose)) {
@@ -336,6 +340,7 @@ public class ObservationValidator extends Harvester {
                 }
             }
         }
+        */
 
         return listErroneous;
     }

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
@@ -174,10 +174,8 @@ public class ObservationValidator extends Harvester {
             timeState = System.currentTimeMillis() - t;
             t = System.currentTimeMillis();
 
-            List<ObservationState> tmpSrcState = null;
-            List<ObservationState> tmpDstState = null;
-
             log.info("getObservationList: " + src.getIdentifier());
+            List<ObservationState> tmpSrcState = null;
             if (srcObservationDAO != null) {
                 tmpSrcState = srcObservationDAO.getObservationList(src.getCollection(), null, null, null);
             } else if (srcObservationService != null) {
@@ -193,7 +191,7 @@ public class ObservationValidator extends Harvester {
             log.info("source set: " + srcState.size());
             
             log.info("getObservationList: " + dest.getIdentifier());
-            tmpDstState = destObservationDAO.getObservationList(dest.getCollection(), null, null, null);
+            List<ObservationState> tmpDstState = destObservationDAO.getObservationList(dest.getCollection(), null, null, null);
             log.info("found: " + tmpDstState.size());
             
             Set<ObservationState> dstState = new TreeSet<>(compStateUri);

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.16'
+version = '2.3.17'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/ObservationDAO.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/ObservationDAO.java
@@ -229,12 +229,12 @@ public class ObservationDAO extends AbstractCaomEntityDAO<Observation> {
         }
     }
 
-    // pdd: temporary hack for use in harvester retring skipped found in above getList impl
+    // pdd: temporary hack for use in harvester retrying skipped
     public ObservationResponse getAlt(ObservationURI uri) {
         long t = System.currentTimeMillis();
 
         try {
-            ObservationState s = new ObservationState(uri);
+            ObservationState s = getState(uri);
             ObservationResponse ret = new ObservationResponse(s);
             try {
                 ret.observation = get(s.getURI());

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/SQLGenerator.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/SQLGenerator.java
@@ -3334,7 +3334,7 @@ public class SQLGenerator {
 
             Observation o = null;
             if (SIMPLE_TYPE.equals(typeCode)) {
-                o = new SimpleObservation(collection, observationID);
+                o = new SimpleObservation(collection, observationID, algorithm);
             } else if (COMPOSITE_TYPE.equals(typeCode)) {
                 o = new CompositeObservation(collection, observationID, algorithm);
             }


### PR DESCRIPTION
Also:
- fix bug in caom2persistence where simple observation algorithm.name not restored from db
- fix caom2harvester --validate mode to keep existing errorMessage  where skip record already exists
- add runtime config of vm heap size for caom2harvester --validate mode
