### PR TITLE
Bug fix for Story 2321. 

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.16'
+version = '2.3.17'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'


### PR DESCRIPTION
The last observation whose lastModified date is stored in HarvestState was reprocessed in a subsequent artifact-discover run. This was because the processing logic did not account for the observation associated with the HarvestState had been processed and should be skipped. Running artifact-discover with '--continue' resulted in an infinite loop.

Build version of cadc-artifact-sync in service.git was also incremented.