### PR TITLE
add CaomRepoConfig option to get a config item without initializing db

### DIFF
--- a/caom2-repo-server/build.gradle
+++ b/caom2-repo-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.13'
+version = '2.3.14'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-repo-server/src/main/java/ca/nrc/cadc/caom2/repo/CaomRepoConfig.java
+++ b/caom2-repo-server/src/main/java/ca/nrc/cadc/caom2/repo/CaomRepoConfig.java
@@ -121,15 +121,21 @@ public class CaomRepoConfig {
     }
     
     public Item getConfig(String collection) {
+        return getConfig(collection, true);
+    }
+    
+    public Item getConfig(String collection, boolean doInit) {
         Iterator<Item> i = config.iterator();
         while (i.hasNext()) {
             Item item = i.next();
             if (item.collection.equals(collection)) {
-                try {
-                    initDB(item);
-                } catch (Exception ex) {
-                    log.error("CAOM database INIT FAILED", ex);
-                    return null;
+                if (doInit) {
+                    try {
+                        initDB(item);
+                    } catch (Exception ex) {
+                        log.error("CAOM database INIT FAILED", ex);
+                        return null;
+                    }
                 }
                 return item;
             }
@@ -141,6 +147,11 @@ public class CaomRepoConfig {
         return config.isEmpty();
     }
 
+    /**
+     * Get a config item iterator that initializes the database before returning items.
+     * 
+     * @return item iterator
+     */
     public Iterator<Item> iterator() {
         return new Initerator(config.iterator());
     }

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.22'
+version = '2.3.23'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/ReadAccessDAO.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/ReadAccessDAO.java
@@ -176,9 +176,9 @@ public class ReadAccessDAO extends AbstractCaomEntityDAO<ReadAccess> {
                 if (obs.isEmpty()) {
                     return null;
                 }
-                if (obs.size() > 1) {
-                    throw new RuntimeException("BUG: get ArtifactAccess " + artifactURI + " query returned " + obs.size() + " rows");
-                }
+                //if (obs.size() > 1) {
+                //    throw new RuntimeException("BUG: get ArtifactAccess " + artifactURI + " query returned " + obs.size() + " rows");
+                //}
                 Object o = obs.get(0);
                 if (o instanceof RawArtifactAccess) {
                     RawArtifactAccess ret = (RawArtifactAccess) o;


### PR DESCRIPTION
made ReadAccessTuplesGenerator database agnostic and separated generate and cleanup methods