### PR TITLE
improved and removed cruft from caom2harvester

### DIFF
--- a/caom2-access-control/build.gradle
+++ b/caom2-access-control/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'checkstyle'
 }
 
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.0'
+version = '2.3.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-access-control/src/main/java/ca/nrc/cadc/caom2/ac/ReadAccessGenerator.java
+++ b/caom2-access-control/src/main/java/ca/nrc/cadc/caom2/ac/ReadAccessGenerator.java
@@ -119,7 +119,7 @@ public class ReadAccessGenerator {
     /**
      * Constructor.
      *
-     * @param collection
+     * @param collection the CAOM collection name
      * @param groupConfig group data from configuration file
      */
     public ReadAccessGenerator(String collection, Map<String, Object> groupConfig) {
@@ -138,7 +138,7 @@ public class ReadAccessGenerator {
      * names are of the form {Observation.collection}-{Observation.proposalID}. The staffGroup is set as
      * an admin of the proposalGroup so a staffGroup is mandatory when proposalGroup is true.
      *
-     * @param collection
+     * @param collection the CAOM collection name
      * @param dryrun only show work if true
      * @param groupConfig group data from configuration file
      */
@@ -172,7 +172,10 @@ public class ReadAccessGenerator {
                 this.groupBaseURI = staffGroupURI.getServiceID();
             }
 
-            this.createProposalGroup = (boolean) groupConfig.get(PROPOSAL_GROUP_KEY);            
+            Object opg = groupConfig.get(PROPOSAL_GROUP_KEY);
+            if (opg instanceof Boolean) { 
+                this.createProposalGroup = (Boolean) opg;
+            }
 
             if (this.createProposalGroup && this.staffGroupURI == null) {
                 

--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'checkstyle'
 }
 

--- a/caom2-persist/build.gradle
+++ b/caom2-persist/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.1'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'checkstyle'
 }
 

--- a/caom2-remove/build.gradle
+++ b/caom2-remove/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'checkstyle'
     id 'application'
 }

--- a/caom2-repo-server/build.gradle
+++ b/caom2-repo-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.16'
+version = '2.3.17'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.opencadc:cadc-cdp:[1.0.1,2.0)'
     compile 'org.opencadc:caom2:[2.3.12,3.0)'
     compile 'org.opencadc:caom2-persist:[2.3.2,3.0)'
-    compile 'org.opencadc:caom2persistence:[2.3.25,3.0)'
+    compile 'org.opencadc:caom2persistence:[2.3.26,3.0)'
     compile 'org.opencadc:cadc-access-control:[1.1.4,)'
     compile 'org.opencadc:cadc-registry:1.+'
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'

--- a/caom2-repo-server/src/main/java/ca/nrc/cadc/caom2/repo/AccessQueryRunner.java
+++ b/caom2-repo-server/src/main/java/ca/nrc/cadc/caom2/repo/AccessQueryRunner.java
@@ -182,21 +182,18 @@ public class AccessQueryRunner implements JobRunner {
                 }
                 List<URI> metaReadAccessGroups = new ArrayList<URI>();
                 List<URI> dataReadAccessGroups = new ArrayList<URI>();
-                LocalAuthority loc = new LocalAuthority();
-                URI gms = loc.getServiceURI(Standards.GMS_GROUPS_01.toASCIIString());
-                for (String s : raa.metaReadAccessGroups) {
-                    URI guri = URI.create(gms.toASCIIString() + "?" + s);
-                    metaReadAccessGroups.add(guri);
+                for (URI mra : raa.metaReadAccessGroups) {
+                    metaReadAccessGroups.add(mra);
                 }
-                for (String s : raa.dataReadAccessGroups) {
-                    URI guri = URI.create(gms.toASCIIString() + "?" + s);
-                    dataReadAccessGroups.add(guri);
+                for (URI dra : raa.dataReadAccessGroups) {
+                    dataReadAccessGroups.add(dra);
                 }
-                ArtifactAccess aa = AccessUtil.getArtifactAccess(raa.artifact,
-                        raa.metaRelease, metaReadAccessGroups, raa.dataRelease, dataReadAccessGroups);
+                ArtifactAccess aa = AccessUtil.getArtifactAccess(raa.artifact, 
+                        raa.metaRelease, metaReadAccessGroups, 
+                        raa.dataRelease, dataReadAccessGroups);
                 ArtifactAccessWriter w = new ArtifactAccessWriter();
                 syncOutput.setHeader("Content-Type", "text/xml");
-                syncOutput.setResponseCode(200);
+                syncOutput.setCode(200);
                 w.write(aa, syncOutput.getOutputStream());
                 logInfo.setSuccess(true);
                 

--- a/caom2-repo/build.gradle
+++ b/caom2-repo/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'application'
     id 'checkstyle'
 }

--- a/caom2-test-repo/build.gradle
+++ b/caom2-test-repo/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'checkstyle'
 }
 

--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.1'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'application'
     id 'checkstyle'
 }

--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.4'
+version = '2.4.5'
 
 mainClassName = 'ca.nrc.cadc.caom2.harvester.Main'
 applicationDefaultJvmArgs = ['-Xms1024m','-Xmx4096m','-XX:OnOutOfMemoryError="kill -3 %p"']
@@ -28,7 +28,7 @@ dependencies {
     
     compile 'org.opencadc:cadc-util:[1.2.2,)'
     compile 'org.opencadc:caom2:[2.3.9,)'
-    compile 'org.opencadc:caom2persistence:[2.3.25,)'
+    compile 'org.opencadc:caom2persistence:[2.3.26,)'
     compile 'org.opencadc:cadc-util:[1.0.14,)'
     compile 'org.opencadc:caom2-repo:[1.3,)'
     compile 'org.opencadc:caom2-persist:[2.3.3,)'
@@ -37,7 +37,7 @@ dependencies {
     compile 'org.opencadc:caom2-compute:[2.3.14,)'
     
     // needed to run access-control regen plugin (--generate-ac)
-    compile 'org.opencadc:caom2-access-control:[2.3.0,)'
+    compile 'org.opencadc:caom2-access-control:[2.3.1,)'
 
     runtime 'net.sourceforge.jtds:jtds:1.+'
     runtime 'org.postgresql:postgresql:9.4.1209.jre7'

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/CaomHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/CaomHarvester.java
@@ -111,8 +111,6 @@ public class CaomHarvester implements Runnable {
      *            base to use in generating Plane publisherID values in destination database
      * @param batchSize
      *            number of observations per batch (~memory consumption)
-     * @param batchFactor
-     *            multiplier for batchSize when harvesting deletions
      * @param full
      *            full harvest of all source entities
      * @param skip
@@ -123,9 +121,7 @@ public class CaomHarvester implements Runnable {
      * @throws java.io.IOException if failing to read config information (.dbrc)
      */
     public CaomHarvester(boolean dryrun, boolean nochecksum, HarvestResource src, HarvestResource dest, URI basePublisherID, int batchSize,
-            int batchFactor, boolean full, boolean skip, int nthreads) throws IOException {
-        Integer entityBatchSize = batchSize * batchFactor;
-
+            boolean full, boolean skip, int nthreads) throws IOException {
         DBConfig dbrc = new DBConfig();
         ConnectionConfig cc = dbrc.getConnectionConfig(dest.getDatabaseServer(), dest.getDatabase());
         DataSource ds = DBUtil.getDataSource(cc);
@@ -137,7 +133,7 @@ public class CaomHarvester implements Runnable {
 
         // deletions in incremental mode only        
         if (!full && !skip && !src.getIdentifier().equals(dest.getIdentifier())) {
-            this.obsDeleter = new DeletionHarvester(DeletedObservation.class, src, dest, entityBatchSize, dryrun);
+            this.obsDeleter = new DeletionHarvester(DeletedObservation.class, src, dest, batchSize * 100, dryrun);
         }
 
         log.info("     source: " + src.getIdentifier());

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/CaomHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/CaomHarvester.java
@@ -120,11 +120,10 @@ public class CaomHarvester implements Runnable {
      * @param nthreads
      *            max threads when harvesting from a service
      * 
-     * @throws java.io.IOException
-     * @throws URISyntaxException
+     * @throws java.io.IOException if failing to read config information (.dbrc)
      */
     public CaomHarvester(boolean dryrun, boolean nochecksum, HarvestResource src, HarvestResource dest, URI basePublisherID, int batchSize,
-            int batchFactor, boolean full, boolean skip, int nthreads) throws IOException, URISyntaxException {
+            int batchFactor, boolean full, boolean skip, int nthreads) throws IOException {
         Integer entityBatchSize = batchSize * batchFactor;
 
         DBConfig dbrc = new DBConfig();
@@ -162,7 +161,7 @@ public class CaomHarvester implements Runnable {
     /**
      * Enable the plane metadata compute plugin.
      * 
-     * @param compute 
+     * @param compute enable Plane metadata computation if true
      */
     public void setCompute(boolean compute) {
         obsHarvester.setComputePlaneMetadata(compute);
@@ -170,7 +169,8 @@ public class CaomHarvester implements Runnable {
     
     /**
      * Enable the generate read access grants plugin with the specified config.
-     * @param config 
+     * 
+     * @param config enable read access generation from the specified config file
      */
     public void setGenerateReadAccess(String config) {
         if (config != null) {

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/DeletionHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/DeletionHarvester.java
@@ -121,13 +121,11 @@ public class DeletionHarvester extends Harvester implements Runnable {
      *            process
      * @throws IOException
      *             IOException
-     * @throws URISyntaxException
-     *             URISyntaxException
      * @throws NumberFormatException
      *             NumberFormatException
      */
     public DeletionHarvester(Class<?> entityClass, HarvestResource src, HarvestResource dest, Integer batchSize, boolean dryrun) throws IOException,
-            NumberFormatException, URISyntaxException {
+            NumberFormatException {
         super(entityClass, src, dest, batchSize, false, dryrun);
         init();
     }
@@ -156,8 +154,6 @@ public class DeletionHarvester extends Harvester implements Runnable {
      *            number of threads to be used
      * @throws IOException
      *             IOException
-     * @throws URISyntaxException
-     *             URISyntaxException
      */
     private void init() throws IOException {
         // source

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -132,12 +132,12 @@ public class Main {
             final boolean skip = am.isSet("skip");
             final boolean dryrun = am.isSet("dryrun");
             final boolean validate = am.isSet("validate");
-            final boolean noChecksum = am.isSet("nochecksum");;
-            final boolean noAC = am.isSet("noac");
             
             // optional plugins
             final boolean compute = am.isSet("compute");
             final String generateAC = am.getValue("generate-ac");
+            final boolean noChecksum = am.isSet("nochecksum") || compute || am.isSet("generate-ac");
+            log.info("accMetaChecksum validation enabled: " + !noChecksum);
 
             // setup optional authentication for harvesting from a web service
             Subject subject = AuthenticationUtil.getAnonSubject();
@@ -215,7 +215,7 @@ public class Main {
                     usage();
                     System.exit(1);
                 }
-                src = new HarvestResource(srcDS[0], srcDS[1], srcDS[2], collection, !noAC);
+                src = new HarvestResource(srcDS[0], srcDS[1], srcDS[2], collection);
             } else if (sourceType == HarvestResource.SOURCE_CAP_URL) {
                 try {
                     src = new HarvestResource(new URL(source), collection);
@@ -400,7 +400,7 @@ public class Main {
 
         sb.append("\n\nSource selection:");
         sb.append("\n          <server.database.schema> : the server and database connection info will be found in $HOME/.dbrc");
-        sb.append("\n          <resourceID> : resource identifier for a registered caom2 repository service (e.g. ivo://cadc.nrc.ca/caom2repo)");
+        sb.append("\n          <resourceID> : resource identifier for a registered caom2 repository service (e.g. ivo://cadc.nrc.ca/ams)");
         sb.append("\n          <capabilities URL> : direct URL to a VOSI capabilities document with caom2 repository endpoints (use: unregistered service)");
         sb.append("\n         [--threads=<num threads>] : number  of threads used to read observation documents (service only, default: 1)");
         
@@ -421,9 +421,10 @@ public class Main {
         sb.append("\n         --batchFactor=<multiplier to batchSize when harvesting deletions (default: ").append(DEFAULT_BATCH_FACTOR).append(")");
         sb.append("\n         --dryrun : check for work but don't do anything");
         sb.append("\n         --nochecksum : do not compare computed and harvested Observation.accMetaChecksum (default: require match or fail)");
+        sb.append("\n                        Note: checksum verification is automatically disabled with either --compute or --generate-ac");
         
         sb.append("\n\nOptional plugin invocation:");
-        sb.append("\n           (probably only useful for CADC; requires --nochecksum since they modify content)");
+        sb.append("\n           (probably only useful for CADC; automatically adds --nochecksum since they modify content)");
         sb.append("\n         --compute : invoke the caom2-compute plugin (computes plane metadata from WCS in artifacts)");
         sb.append("\n         --generate-ac=<config file> : invoke the caom2-access-control plugin (generates grants for proprietary metadata and data)");
         sb.append("\n                       <config file> is a properties file with <collection> = <same generate options as caom2-repo-server>");

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -265,22 +265,11 @@ public class Main {
             }
 
             Integer batchSize = null;
-            Integer batchFactor = null;
             String sbatch = am.getValue("batchSize");
-            String sfactor = am.getValue("batchFactor");
 
             if (sbatch != null && sbatch.trim().length() > 0) {
                 try {
                     batchSize = new Integer(sbatch);
-                } catch (NumberFormatException nex) {
-                    usage();
-                    log.error("value for --batchSize must be an integer, found: " + sbatch);
-                    System.exit(1);
-                }
-            }
-            if (sfactor != null && sfactor.trim().length() > 0) {
-                try {
-                    batchFactor = new Integer(sfactor);
                 } catch (NumberFormatException nex) {
                     usage();
                     log.error("value for --batchSize must be an integer, found: " + sbatch);
@@ -292,12 +281,8 @@ public class Main {
                 log.debug("no --batchSize specified: defaulting to " + DEFAULT_BATCH_SIZE);
                 batchSize = DEFAULT_BATCH_SIZE;
             }
-            if (batchFactor == null && batchSize != null) {
-                log.debug("no --batchFactor specified: defaulting to " + DEFAULT_BATCH_FACTOR);
-                batchFactor = DEFAULT_BATCH_FACTOR;
-            }
             if (!validate) {
-                log.info("batchSize: " + batchSize + "  batchFactor: " + batchFactor);
+                log.info("batchSize: " + batchSize);
             }
 
             Date minDate = null;
@@ -329,7 +314,7 @@ public class Main {
             if (!validate) {
 
                 try {
-                    CaomHarvester ch = new CaomHarvester(dryrun, noChecksum, src, dest, basePublisherID, batchSize, batchFactor, full, skip, nthreads);
+                    CaomHarvester ch = new CaomHarvester(dryrun, noChecksum, src, dest, basePublisherID, batchSize, full, skip, nthreads);
                     ch.setMinDate(minDate);
                     ch.setMaxDate(maxDate);
                     ch.setCompute(compute);
@@ -415,11 +400,10 @@ public class Main {
         sb.append("\n         --cert=<pem file> : read client certificate from PEM file");
 
         sb.append("\n\nOptional modifiers:");
+        sb.append("\n         --batchSize=<number of observations per batch> (default: ").append(DEFAULT_BATCH_SIZE).append(")");
+        sb.append("\n         --dryrun : check for work but don't do anything");
         sb.append("\n         --minDate=<minimum Observation.maxLastModfied to consider (UTC timestamp)");
         sb.append("\n         --maxDate=<maximum Observation.maxLastModfied to consider (UTC timestamp)");
-        sb.append("\n         --batchSize=<number of observations per batch> (default: ").append(DEFAULT_BATCH_SIZE).append(")");
-        sb.append("\n         --batchFactor=<multiplier to batchSize when harvesting deletions (default: ").append(DEFAULT_BATCH_FACTOR).append(")");
-        sb.append("\n         --dryrun : check for work but don't do anything");
         sb.append("\n         --nochecksum : do not compare computed and harvested Observation.accMetaChecksum (default: require match or fail)");
         sb.append("\n                        Note: checksum verification is automatically disabled with either --compute or --generate-ac");
         

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
@@ -134,7 +134,7 @@ public class ObservationHarvester extends Harvester {
     HarvestSkipURIDAO harvestSkipDAO = null;
 
     public ObservationHarvester(HarvestResource src, HarvestResource dest, URI basePublisherID, Integer batchSize, boolean full, boolean dryrun,
-            boolean nochecksum, int nthreads) throws IOException, URISyntaxException {
+            boolean nochecksum, int nthreads) throws IOException {
         super(Observation.class, src, dest, batchSize, full, dryrun);
         this.nochecksum = nochecksum;
         this.basePublisherID = basePublisherID;
@@ -200,7 +200,7 @@ public class ObservationHarvester extends Harvester {
         } 
     }
 
-    private void init(int nthreads) throws IOException, URISyntaxException {
+    private void init(int nthreads) throws IOException {
         if (src.getResourceType() == HarvestResource.SOURCE_DB && src.getDatabaseServer() != null) {
             Map<String, Object> config1 = getConfigDAO(src);
             this.srcObservationDAO = new ObservationDAO();

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
@@ -151,6 +151,7 @@ public class ObservationHarvester extends Harvester {
     
     public void setComputePlaneMetadata(boolean computePlaneMetadata) {
         this.computePlaneMetadata = computePlaneMetadata;
+        this.destObservationDAO.setOrigin(true);
     }
 
     public void setGenerateReadAccessTuples(File config) {
@@ -193,6 +194,7 @@ public class ObservationHarvester extends Harvester {
                 log.debug("generate config for " + src.getCollection() + ": " + me.getKey() + " = " + me.getValue());
             }
             this.acGenerator = new ReadAccessGenerator(src.getCollection(), groupConfig);
+            this.destObservationDAO.setOrigin(true);
         } catch (IOException ex) {
             throw new RuntimeException("failed to read config from " + config, ex);
         } catch (Exception ex) {

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationValidator.java
@@ -330,18 +330,14 @@ public class ObservationValidator extends Harvester {
                 if (!listErroneous.contains(ose)) {
                     listErroneous.add(ose);
                 }
-            } 
-        }
-        /*
-          else if (!nochecksum && !listCorrect.contains(os)) {
-                ObservationStateError ose = new ObservationStateError(os, "computation or serialization bug");
-                log.info("************************ adding computation or serialization bug: " + os.getURI());
+            } else if (!nochecksum && !listCorrect.contains(os)) {
+                ObservationStateError ose = new ObservationStateError(os, "mismatched accMetaChecksum");
+                log.info("************************ adding mismatched accMetaChecksum: " + os.getURI());
                 if (!listErroneous.contains(ose)) {
                     listErroneous.add(ose);
                 }
             }
         }
-        */
 
         return listErroneous;
     }

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.1'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'application'
     id 'checkstyle'
 }

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.25'
+version = '2.3.26'
 
 mainClassName = 'ca.nrc.cadc.caom2.version.Main'
 

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/harvester/HarvestResource.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/harvester/HarvestResource.java
@@ -86,7 +86,6 @@ public class HarvestResource {
     private String databaseServer;
     private String database;
     private String schema;
-    private boolean harvestAC;
 
     private URI resourceID;
     private URL capabilitiesURL;
@@ -114,24 +113,6 @@ public class HarvestResource {
      *            name of collection to harvest
      */
     public HarvestResource(String databaseServer, String database, String schema, String collection) {
-        this(databaseServer, database, schema, collection, true);
-    }
-
-    /**
-     * Create a HarvestResource for a database.
-     *
-     * @param databaseServer
-     *            server name in $HOME/.dbrc
-     * @param database
-     *            database name in $HOME/.dbrc and query generation
-     * @param schema
-     *            schema name for query generation
-     * @param collection
-     *            name of collection to harvest
-     * @param harvestAC
-     *            true to enable harvesting access control tuples
-     */
-    public HarvestResource(String databaseServer, String database, String schema, String collection, boolean harvestAC) {
         if (databaseServer == null || database == null || schema == null || collection == null) {
             throw new IllegalArgumentException("args cannot be null");
         }
@@ -139,7 +120,6 @@ public class HarvestResource {
         this.database = database;
         this.schema = schema;
         this.collection = collection;
-        this.harvestAC = harvestAC;
         this.resourceType = SOURCE_DB;
     }
 
@@ -149,7 +129,6 @@ public class HarvestResource {
         }
         this.resourceID = resourceID;
         this.collection = collection;
-        this.harvestAC = true; // no API for this
         this.resourceType = SOURCE_URI;
     }
 
@@ -159,7 +138,6 @@ public class HarvestResource {
         }
         this.capabilitiesURL = resourceCapabilitiesURL;
         this.collection = collection;
-        this.harvestAC = true; // no API for this
         this.resourceType = SOURCE_CAP_URL;
     }
 
@@ -182,10 +160,6 @@ public class HarvestResource {
 
     public String getSchema() {
         return schema;
-    }
-
-    public boolean getHarvestAC() {
-        return harvestAC;
     }
 
     public URI getResourceID() {

--- a/caom2persistence/src/main/resources/postgresql/caom2.drop_all.sql
+++ b/caom2persistence/src/main/resources/postgresql/caom2.drop_all.sql
@@ -15,14 +15,7 @@ drop table if exists <schema>.Plane;
 drop table if exists <schema>.ObservationMember;
 drop table if exists <schema>.Observation;
 
-drop table if exists <schema>.ObservationMetaReadAccess;
-drop table if exists <schema>.PlaneMetaReadAccess;
-drop table if exists <schema>.PlaneDataReadAccess;
-
 drop table if exists <schema>.DeletedObservation;
-drop table if exists <schema>.DeletedObservationMetaReadAccess;
-drop table if exists <schema>.DeletedPlaneMetaReadAccess;
-drop table if exists <schema>.DeletedPlaneDataReadAccess;
 
 drop table if exists <schema>.HarvestState;
 drop table if exists <schema>.HarvestSkip;


### PR DESCRIPTION
redesigned use of --compute and --generate-ac to be optional plugins that can be used to reprocess/backfill in a single database

--compute and --generate-ac modify content and there is risk to mess things up  if misused so they are disabled by a hard coded flag; if someone really wants to use these features they need to change the flag and build a custom version of the application.

changed ReadAccessDAO.getArtifactAccess to use the columns with complete group URIs instead of just names; this removes the need for a LocalAuthority and assumptions that all groups are local (eg in a caom2-repo-server ArtifactAccessRunner deployment ).