### PR TITLE
s2422, ams integration tests

### DIFF
--- a/caom2-test-repo/build.gradle
+++ b/caom2-test-repo/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.0.18'
+version = '1.0.19'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-test-repo/src/main/java/ca/nrc/cadc/caom2/repo/integration/CaomRepoDeletedTest.java
+++ b/caom2-test-repo/src/main/java/ca/nrc/cadc/caom2/repo/integration/CaomRepoDeletedTest.java
@@ -174,10 +174,8 @@ public class CaomRepoDeletedTest extends CaomRepoBaseIntTests {
             log.info("testListDeletedSuccess deleted: " + obs.getURI());
             Date clientDeleted = new Date();
             final long localDt = clientDeleted.getTime() - clientInserted.getTime();
-
             Date endDate = new Date(inserted.getTime() + localDt + 100);
 
-            log.info("clock skew: " + df.format(clientDeleted) + " -> " + df.format(endDate));
             log.info("local operation dt: " + df.format(clientDeleted) + " -> " + df.format(clientInserted));
 
             StringBuilder sb = new StringBuilder();

--- a/caom2-test-repo/src/main/java/ca/nrc/cadc/caom2/repo/integration/CaomRepoDeletedTest.java
+++ b/caom2-test-repo/src/main/java/ca/nrc/cadc/caom2/repo/integration/CaomRepoDeletedTest.java
@@ -164,18 +164,21 @@ public class CaomRepoDeletedTest extends CaomRepoBaseIntTests {
             Observation obs = new SimpleObservation(TEST_COLLECTION, "testListDeletedSuccess-" + UUID.randomUUID().toString());
 
             rc.putObservation(obs, subject1, 200, "OK", null);
+            Date clientInserted = new Date();
             obs = rc.getObservation(obs.getURI().getURI().toASCIIString(), subject1, 200, null, null);
             Assert.assertNotNull("test setup", obs);
             Date inserted = obs.getMaxLastModified();
-            Date clientInserted = new Date();
-            final long dt = inserted.getTime() - clientInserted.getTime();
             log.info("testListDeletedSuccess inserted: " + obs.getURI() + " " + df.format(obs.getMaxLastModified()));
             
             rc.deleteObservation(obs.getURI().getURI().toASCIIString(), subject1, null, null);
             log.info("testListDeletedSuccess deleted: " + obs.getURI());
             Date clientDeleted = new Date();
-            Date endDate = new Date(clientDeleted.getTime() - dt);
+            final long localDt = clientDeleted.getTime() - clientInserted.getTime();
+
+            Date endDate = new Date(inserted.getTime() + localDt + 100);
+
             log.info("clock skew: " + df.format(clientDeleted) + " -> " + df.format(endDate));
+            log.info("local operation dt: " + df.format(clientDeleted) + " -> " + df.format(clientInserted));
 
             StringBuilder sb = new StringBuilder();
             sb.append(baseHTTPSURL).append("/").append(TEST_COLLECTION);


### PR DESCRIPTION
Getting the tests to run: CaomRepoDeletedTest.testListDeletedSuccess wasn't catching the deleted observation in ams's 'RepoDeletedTest', so that test failed consistently. 