### PR TITLE
 harvester bug fix: only set origin mode in ObservationDAO when needed

### DIFF
--- a/caom2harvester/build.gradle
+++ b/caom2harvester/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.7'
+version = '2.4.8'
 
 mainClassName = 'ca.nrc.cadc.caom2.harvester.Main'
 applicationDefaultJvmArgs = ['-Xms1024m','-Xmx4096m','-XX:OnOutOfMemoryError="kill -3 %p"']

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/CaomHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/CaomHarvester.java
@@ -169,9 +169,7 @@ public class CaomHarvester implements Runnable {
      * @param config enable read access generation from the specified config file
      */
     public void setGenerateReadAccess(String config) {
-        if (config != null) {
-            obsHarvester.setGenerateReadAccessTuples(new File(config));
-        }
+        obsHarvester.setGenerateReadAccessTuples(new File(config));
     }
 
     @Override

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -331,7 +331,9 @@ public class Main {
                     ch.setMinDate(minDate);
                     ch.setMaxDate(maxDate);
                     ch.setCompute(compute);
-                    ch.setGenerateReadAccess(generateAC);
+                    if (generateAC != null) {
+                        ch.setGenerateReadAccess(generateAC);
+                    }
                     action = ch;
                 } catch (IOException ioex) {
 

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/ObservationHarvester.java
@@ -152,7 +152,10 @@ public class ObservationHarvester extends Harvester {
     
     public void setComputePlaneMetadata(boolean computePlaneMetadata) {
         this.computePlaneMetadata = computePlaneMetadata;
-        this.destObservationDAO.setOrigin(true);
+        if (computePlaneMetadata) {
+            log.info("computePlaneMeta: setting origin=true");
+            this.destObservationDAO.setOrigin(true);
+        }
     }
 
     public void setGenerateReadAccessTuples(File config) {
@@ -195,6 +198,7 @@ public class ObservationHarvester extends Harvester {
                 log.debug("generate config for " + src.getCollection() + ": " + me.getKey() + " = " + me.getValue());
             }
             this.acGenerator = new ReadAccessGenerator(src.getCollection(), groupConfig);
+            log.info("generateAC: setting origin=true");
             this.destObservationDAO.setOrigin(true);
         } catch (IOException ex) {
             throw new RuntimeException("failed to read config from " + config, ex);

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/AbstractCaomEntityDAO.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/AbstractCaomEntityDAO.java
@@ -140,10 +140,17 @@ abstract class AbstractCaomEntityDAO<T extends CaomEntity> extends AbstractDAO {
 
             // change in accMetaChecksum means maxLastModified changed
             // this correctly maintains accMetaChecksum and maxLastModified
-            if (!delta && val.getAccMetaChecksum() != null) {
+            if (!delta) {
                 delta = !val.getAccMetaChecksum().equals(cur.accMetaChecksum);
                 cmp = cmp + " -- " + cur.accMetaChecksum + " vs " + val.getAccMetaChecksum();
             }
+            
+            // temporary(?) work-around for a caom2harvester bug that set origin=true and assigned new timestamps
+            // if not origin but lastModified values are inconsistent: force an update
+            if (!origin && !delta) {
+                delta = !val.getLastModified().equals(cur.lastModified) || !val.getMaxLastModified().equals(cur.maxLastModified);
+            }
+            // end of work-around
             log.debug("PUT: " + val.getClass().getSimpleName() + cmp);
         } else {
             log.debug("PUT: " + val.getClass().getSimpleName() + cmp);

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/ObservationDAO.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/ObservationDAO.java
@@ -437,10 +437,12 @@ public class ObservationDAO extends AbstractCaomEntityDAO<Observation> {
             getTransactionManager().startTransaction();
             txnOpen = true;
             
-            // obtain row lock on observation
-            String lock = gen.getUpdateLockSQL(obs);
-            log.debug("LOCK SQL: " + lock);
-            jdbc.update(lock);
+            // obtain row lock on observation update
+            if (cur != null) {
+                String lock = gen.getUpdateLockSQL(obs);
+                log.debug("LOCK SQL: " + lock);
+                jdbc.update(lock);
+            }
             
             // delete obsolete children
             List<Pair<Plane>> pairs = new ArrayList<Pair<Plane>>();


### PR DESCRIPTION
normally origin=false for harvester so that lastModified and maxLastModified timestamps from source are retained; if the optional compute and/or generateAC plugins (to backfill or correct values in a repository db) then origin is set to true to also manage timestamps.

A bug introduced on Nov 5 was always setting origin = true