### PR TITLE
Enhanced discovery and diff to enumerate files missing from storage

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.27'
+version = '2.3.28'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -96,6 +96,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
 
     public static final Integer DEFAULT_BATCH_SIZE = Integer.valueOf(1000);
     public static final String STATE_CLASS = Artifact.class.getSimpleName();
+    public static final String PROPRIETARY = "proprietary";
 
     private static final Logger log = Logger.getLogger(ArtifactHarvester.class);
 
@@ -223,7 +224,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                                         if (skip == null) {
                                             if (downloadDate.after(start)) {
                                                 // proprietary--download in the future
-                                                skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate);
+                                                skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate, PROPRIETARY);
                                             } else {
                                                 boolean correctCopy = artifactStore.contains(artifact.getURI(), artifact
                                                     .contentChecksum);
@@ -247,6 +248,10 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                                         log.error(message, t);
                                         log.debug("Adding artifact to skip table: " + artifact.getURI());
                                         HarvestSkipURI skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate);
+                                        if (downloadDate.after(start)) {
+                                            // proprietary--download in the future
+                                            skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate, PROPRIETARY);
+                                        }
                                         harvestSkipURIDAO.put(skip);
                                         added = true;
                                     } finally {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -3,7 +3,7 @@
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
  **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
  *
- *  (c) 2017.                            (c) 2017.
+ *  (c) 2019.                            (c) 2019.
  *  Government of Canada                 Gouvernement du Canada
  *  National Research Council            Conseil national de recherches
  *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -209,57 +209,57 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                                     // null date means private
                                     log.debug("null release date, skipping");
                                 } else {
-        
                                     logStart(artifact);
                                     boolean success = true;
+                                    boolean addToSkip = false;
                                     boolean added = false;
                                     String message = null;
-                                    try {
-                                        processedCount++;
-                                        
-                                        // see if there's already an entry
-                                        HarvestSkipURI skip = harvestSkipURIDAO.get(source, STATE_CLASS, artifact
-                                            .getURI());
-                                        
-                                        if (skip == null) {
-                                            if (downloadDate.after(start)) {
-                                                // proprietary--download in the future
-                                                skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate, PROPRIETARY);
-                                            } else {
-                                                boolean correctCopy = artifactStore.contains(artifact.getURI(), artifact
-                                                    .contentChecksum);
-                                                log.debug("Artifact " + artifact.getURI() + " with MD5 " + artifact
-                                                    .contentChecksum + " correct copy: " + correctCopy);
-                                                if (!correctCopy) {
-                                                    skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate);
-                                                }
-                                            }
-                                            if (skip != null) {
-                                                harvestSkipURIDAO.put(skip);
-                                                added = true;
-                                            }
-                                        } else {
-                                            message = "Artifact already exists in skip table.";
-                                        }
-                                    } catch (Throwable t) {
-                                        success = false;
-                                        message = "Failed to determine if artifact " + artifact.getURI() + " exists: "
-                                            + t.getMessage();
-                                        log.error(message, t);
-                                        log.debug("Adding artifact to skip table: " + artifact.getURI());
-                                        HarvestSkipURI skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate);
-                                        if (downloadDate.after(start)) {
-                                            // proprietary--download in the future
-                                            skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate, PROPRIETARY);
-                                        }
-                                        harvestSkipURIDAO.put(skip);
-                                        added = true;
-                                    } finally {
-                                        logEnd(artifact, success, added, message);
-                                        if (added) {
-                                            downloadCount++;
+                                    String errorMessage = null;
+                                    processedCount++;
+                                    
+                                    if (downloadDate.after(start) ) {
+                                        // private--download in the future
+                                        errorMessage = PROPRIETARY;
+                                    } 
+                                    
+                                    // see if there's already an entry
+                                    HarvestSkipURI skip = harvestSkipURIDAO.get(source, STATE_CLASS, artifact.getURI());
+                                    if (skip == null) {
+                                        // not in skip table but may be in artifactStore already, may be private or public
+                                        skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), downloadDate, errorMessage);
+                                        addToSkip = true;
+                                    } else {
+                                        message = "Artifact already exists in skip table.";
+                                        if (errorMessage != null) {
+                                            // artifact is private
+                                            addToSkip = true;
+                                            skip.setTryAfter(downloadDate);
+                                            skip.errorMessage = errorMessage;
                                         }
                                     }
+                                    
+                                    try {
+                                        if (addToSkip && errorMessage == null) {
+                                            // public artifact not in skip table
+                                            boolean correctCopy = artifactStore.contains(artifact.getURI(), artifact
+                                                    .contentChecksum);
+                                            log.debug("Artifact " + artifact.getURI() + " with MD5 " + artifact
+                                                .contentChecksum + " correct copy: " + correctCopy);
+                                            addToSkip = !correctCopy;
+                                        }
+                                    } catch (Exception ex) {
+                                        success = false;
+                                        message = "Failed to determine if artifact " + artifact.getURI() + " exists: " + ex.getMessage();
+                                        log.error(message, ex);
+                                    }
+                                    
+                                    if (addToSkip) {
+                                        harvestSkipURIDAO.put(skip);
+                                        added = true;
+                                        downloadCount++;
+                                    }
+                                    
+                                    logEnd(artifact, success, added, message);
                                 }
                             }
                         }

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -217,7 +217,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                                     String errorMessage = null;
                                     processedCount++;
                                     
-                                    if (downloadDate.after(start) ) {
+                                    if (downloadDate.after(start)) {
                                         // private--download in the future
                                         errorMessage = PROPRIETARY;
                                     } 

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -94,7 +94,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.security.PrivilegedExceptionAction;
 import java.text.DateFormat;
-import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.ListIterator;
@@ -380,7 +379,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
         } else {
             // add proprietary artifacts to the skip table and remove them from artifacts
             TreeSet<ArtifactMetadata> publicArtifacts = new TreeSet<>(ArtifactMetadata.getComparator());
-            Date now = Date.from(Instant.now());
+            Date now = new Date();
             for (ArtifactMetadata artifact : artifacts) {
                 if (artifact.releaseDate == null) {
                     // null release date means private, skip the artifact 

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -315,14 +315,14 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
             } else {
                 missingFromStorage++;
                 logJSON(new String[]
-                        {"logType", "detail",
-                         "anomaly", "missingFromStorage",
-                         "observationID", artifact.observationID,
-                         "artifactURI", artifact.artifactURI,
-                         "storageID", artifact.storageID,
-                         "caomCollection", collection,
-                         "caomLastModified", lastModified},
-                        false);
+                    {"logType", "detail",
+                     "anomaly", "missingFromStorage",
+                     "observationID", artifact.observationID,
+                     "artifactURI", artifact.artifactURI,
+                     "storageID", artifact.storageID,
+                     "caomCollection", collection,
+                     "caomLastModified", lastModified},
+                    false);
             }
 
             // add to HavestSkipURI table if there is not already a row in the table

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2018.                            (c) 2018.
+*  (c) 2019.                            (c) 2019.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -375,7 +375,9 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
    
     private TreeSet<ArtifactMetadata> removeProprietaryArtifacts(TreeSet<ArtifactMetadata> artifacts) throws URISyntaxException {
         // add proprietary artifacts only in validate mode
-        if (!reportOnly) {
+        if (reportOnly) {
+            return artifacts;
+        } else {
             // add proprietary artifacts to the skip table and remove them from artifacts
             TreeSet<ArtifactMetadata> publicArtifacts = new TreeSet<>(ArtifactMetadata.getComparator());
             Date now = Date.from(Instant.now());
@@ -410,11 +412,8 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
             }
             
             return publicArtifacts;
-        } else {
-            return artifacts;
         }
     }
-    
     
     private void logJSON(String[] data, boolean summaryInfo) {
         StringBuilder sb = new StringBuilder();

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -309,28 +309,30 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
             if (artifact.releaseDate == null) {
                 // null release date means private, skip the artifact 
                 log.debug("null release date, skipping " + artifact.artifactURI);
-            } else if (artifact.releaseDate.after(now)) {
-                // proprietary artifact with a release date, add to skip table
-                errorMessage = ArtifactHarvester.PROPRIETARY;
             } else {
-                missingFromStorage++;
-                logJSON(new String[]
-                    {"logType", "detail",
-                     "anomaly", "missingFromStorage",
-                     "observationID", artifact.observationID,
-                     "artifactURI", artifact.artifactURI,
-                     "storageID", artifact.storageID,
-                     "caomCollection", collection,
-                     "caomLastModified", lastModified},
-                    false);
-            }
-
-            // add to HavestSkipURI table if there is not already a row in the table
-            if (supportSkipURITable) {
-                if (checkAddToSkipTable(artifact, errorMessage)) {
-                    skipURICount++;
+                if (artifact.releaseDate.after(now)) {
+                    // proprietary artifact with a release date, add to skip table
+                    errorMessage = ArtifactHarvester.PROPRIETARY;
                 } else {
-                    inSkipURICount++;
+                    missingFromStorage++;
+                    logJSON(new String[]
+                        {"logType", "detail",
+                         "anomaly", "missingFromStorage",
+                         "observationID", artifact.observationID,
+                         "artifactURI", artifact.artifactURI,
+                         "storageID", artifact.storageID,
+                         "caomCollection", collection,
+                         "caomLastModified", lastModified},
+                        false);
+                }
+    
+                // add to HavestSkipURI table if there is not already a row in the table
+                if (supportSkipURITable) {
+                    if (checkAddToSkipTable(artifact, errorMessage)) {
+                        skipURICount++;
+                    } else {
+                        inSkipURICount++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
We want artifact-diff and artifact-validate summary to indicate the number of files that should be in storage but are not.

Let A be the set of artifacts in CAOM,
      F be the sert of artifacts in storage,
      P be the set of proprietary files in the HarvestSkipURI table,
      M be the set of files missing from storage
then M = (A - F) - P 

The changes in this pull request include updates to caom2-artifact-sync to mark a private artifact at discovery time and calculate the number of missing file from storage included in the artifact-diff and artifact-validate summary.