### PR TITLE
Change the way CAOM artifacts with null checksums are handled

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,11 +15,11 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.29'
+version = '2.3.30'
 
 dependencies {
-    compile 'log4j:log4j:[1.2.+,)'
-    compile 'org.jdom:jdom2:[2.+,)'
+    compile 'log4j:log4j:[1.2.0,)'
+    compile 'org.jdom:jdom2:[2.0,)'
     compile 'org.springframework:spring-jdbc:2.5.6.SEC01'
 
     compile 'org.opencadc:cadc-util:[1.0.17,)'
@@ -31,7 +31,7 @@ dependencies {
     compile 'org.opencadc:caom2-artifact-resolvers:[1.1.11,)'
     compile 'org.opencadc:cadc-tap:[1.0,)'
 
-    runtime 'net.sourceforge.jtds:jtds:[1.+,)'
+    runtime 'net.sourceforge.jtds:jtds:[1.0,)'
     runtime 'org.postgresql:postgresql:9.4.1209.jre7'
     
     testCompile 'junit:junit:[4.+,)'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -264,7 +264,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                             correct++;
                         }
                     } else {
-                        // artifact with null or empty checksums are considered correct
+                        // artifact with null or empty checksum is considered correct
                         correct++;
                     }
                 } else {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -225,39 +225,46 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                 if (nextLogical.lastModified != null) {
                     logicalicalLastModified = df.format(nextLogical.lastModified);
                 }
-                if (nextLogical.checksum != null && nextLogical.checksum.equals(nextPhysical.checksum)) {
-                    // check content length
-                    if (nextLogical.contentLength == null 
-                            || !nextLogical.contentLength.equals(nextPhysical.contentLength)) {
-                        diffLength++;
-                        logJSON(new String[]
-                            {"logType", "detail",
-                             "anomaly", "diffLength",
-                             "observationID", nextLogical.observationID,
-                             "artifactURI", nextLogical.artifactURI.toString(),
-                             "storageID", nextLogical.storageID,
-                             "caomContentLength", nextLogical.contentLength,
-                             "storageContentLength", nextPhysical.contentLength,
-                             "caomCollection", collection,
-                             "caomLastModified", logicalicalLastModified,
-                             "ingestDate", physicalLastModified},
-                            false);
-                    } else if (nextLogical.contentType == null
-                            || !nextLogical.contentType.equals(nextPhysical.contentType)) {
-                        diffType++;
-                        logJSON(new String[]
-                            {"logType", "detail",
-                             "anomaly", "diffType",
-                             "observationID", nextLogical.observationID,
-                             "artifactURI", nextLogical.artifactURI.toString(),
-                             "storageID", nextLogical.storageID,
-                             "caomContentType", nextLogical.contentType,
-                             "storageContentType", nextPhysical.contentType,
-                             "caomCollection", collection,
-                             "caomLastModified", logicalicalLastModified,
-                             "ingestDate", physicalLastModified},
-                            false);
+                if (nextPhysical.checksum != null) {
+                    if (nextLogical.checksum != null && nextLogical.checksum.length() > 0 &&
+                        nextLogical.checksum.equals(nextPhysical.checksum)) {
+                        // check content length
+                        if (nextLogical.contentLength == null 
+                                || !nextLogical.contentLength.equals(nextPhysical.contentLength)) {
+                            diffLength++;
+                            logJSON(new String[]
+                                {"logType", "detail",
+                                 "anomaly", "diffLength",
+                                 "observationID", nextLogical.observationID,
+                                 "artifactURI", nextLogical.artifactURI.toString(),
+                                 "storageID", nextLogical.storageID,
+                                 "caomContentLength", nextLogical.contentLength,
+                                 "storageContentLength", nextPhysical.contentLength,
+                                 "caomCollection", collection,
+                                 "caomLastModified", logicalicalLastModified,
+                                 "ingestDate", physicalLastModified},
+                                false);
+                        } else if (nextLogical.contentType == null
+                                || !nextLogical.contentType.equals(nextPhysical.contentType)) {
+                            diffType++;
+                            logJSON(new String[]
+                                {"logType", "detail",
+                                 "anomaly", "diffType",
+                                 "observationID", nextLogical.observationID,
+                                 "artifactURI", nextLogical.artifactURI.toString(),
+                                 "storageID", nextLogical.storageID,
+                                 "caomContentType", nextLogical.contentType,
+                                 "storageContentType", nextPhysical.contentType,
+                                 "caomCollection", collection,
+                                 "caomLastModified", logicalicalLastModified,
+                                 "ingestDate", physicalLastModified},
+                                false);
+                        } else {
+                            // artifact with matched checksum, contentLength and contentType
+                            correct++;
+                        }
                     } else {
+                        // artifact with null or empty checksums are considered correct
                         correct++;
                     }
                 } else {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -225,47 +225,42 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                 if (nextLogical.lastModified != null) {
                     logicalicalLastModified = df.format(nextLogical.lastModified);
                 }
-                if (nextPhysical.checksum != null) {
-                    if (nextLogical.checksum != null && nextLogical.checksum.length() > 0
-                        && nextLogical.checksum.equals(nextPhysical.checksum)) {
-                        // check content length
-                        if (nextLogical.contentLength == null 
-                                || !nextLogical.contentLength.equals(nextPhysical.contentLength)) {
-                            diffLength++;
-                            logJSON(new String[]
-                                {"logType", "detail",
-                                 "anomaly", "diffLength",
-                                 "observationID", nextLogical.observationID,
-                                 "artifactURI", nextLogical.artifactURI.toString(),
-                                 "storageID", nextLogical.storageID,
-                                 "caomContentLength", nextLogical.contentLength,
-                                 "storageContentLength", nextPhysical.contentLength,
-                                 "caomCollection", collection,
-                                 "caomLastModified", logicalicalLastModified,
-                                 "ingestDate", physicalLastModified},
-                                false);
-                        } else if (nextLogical.contentType == null
-                                || !nextLogical.contentType.equals(nextPhysical.contentType)) {
-                            diffType++;
-                            logJSON(new String[]
-                                {"logType", "detail",
-                                 "anomaly", "diffType",
-                                 "observationID", nextLogical.observationID,
-                                 "artifactURI", nextLogical.artifactURI.toString(),
-                                 "storageID", nextLogical.storageID,
-                                 "caomContentType", nextLogical.contentType,
-                                 "storageContentType", nextPhysical.contentType,
-                                 "caomCollection", collection,
-                                 "caomLastModified", logicalicalLastModified,
-                                 "ingestDate", physicalLastModified},
-                                false);
-                        } else {
-                            // artifact with matched checksum, contentLength and contentType
-                            correct++;
-                        }
+                if (nextLogical.checksum == null || nextLogical.checksum.length() == 0) {
+                    correct++;
+                } else if (nextLogical.checksum.equals(nextPhysical.checksum)) {
+                    // check content length
+                    if (nextLogical.contentLength == null 
+                            || !nextLogical.contentLength.equals(nextPhysical.contentLength)) {
+                        diffLength++;
+                        logJSON(new String[]
+                            {"logType", "detail",
+                             "anomaly", "diffLength",
+                             "observationID", nextLogical.observationID,
+                             "artifactURI", nextLogical.artifactURI.toString(),
+                             "storageID", nextLogical.storageID,
+                             "caomContentLength", nextLogical.contentLength,
+                             "storageContentLength", nextPhysical.contentLength,
+                             "caomCollection", collection,
+                             "caomLastModified", logicalicalLastModified,
+                             "ingestDate", physicalLastModified},
+                            false);
+                    } else if (nextLogical.contentType == null
+                            || !nextLogical.contentType.equals(nextPhysical.contentType)) {
+                        diffType++;
+                        logJSON(new String[]
+                            {"logType", "detail",
+                             "anomaly", "diffType",
+                             "observationID", nextLogical.observationID,
+                             "artifactURI", nextLogical.artifactURI.toString(),
+                             "storageID", nextLogical.storageID,
+                             "caomContentType", nextLogical.contentType,
+                             "storageContentType", nextPhysical.contentType,
+                             "caomCollection", collection,
+                             "caomLastModified", logicalicalLastModified,
+                             "ingestDate", physicalLastModified},
+                            false);
                     } else {
-                        // artifact with null or empty checksum is considered correct, 
-                        // irrespective of its contentLength or contentType
+                        // artifact with matched checksum, contentLength and contentType
                         correct++;
                     }
                 } else {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -226,8 +226,8 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                     logicalicalLastModified = df.format(nextLogical.lastModified);
                 }
                 if (nextPhysical.checksum != null) {
-                    if (nextLogical.checksum != null && nextLogical.checksum.length() > 0 &&
-                        nextLogical.checksum.equals(nextPhysical.checksum)) {
+                    if (nextLogical.checksum != null && nextLogical.checksum.length() > 0
+                        && nextLogical.checksum.equals(nextPhysical.checksum)) {
                         // check content length
                         if (nextLogical.contentLength == null 
                                 || !nextLogical.contentLength.equals(nextPhysical.contentLength)) {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -226,6 +226,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                     logicalicalLastModified = df.format(nextLogical.lastModified);
                 }
                 if (nextLogical.checksum == null || nextLogical.checksum.length() == 0) {
+                    // an artifact with null or empty checksum is considered to be correct
                     correct++;
                 } else if (nextLogical.checksum.equals(nextPhysical.checksum)) {
                     // check content length

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -264,7 +264,8 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                             correct++;
                         }
                     } else {
-                        // artifact with null or empty checksum is considered correct
+                        // artifact with null or empty checksum is considered correct, 
+                        // irrespective of its contentLength or contentType
                         correct++;
                     }
                 } else {


### PR DESCRIPTION
Currently a CAOM artifact with a null checksum is considered incorrect and is added to the skip URI table to be downloaded. After the artifact has been downloaded, the artifact entry is removed from the skip URI table. The next time when artifact-validate is executed, if its checksum is still null, the same CAOM artifact is added to the skip URI table to be downloaded again. This cycle repeats indefinitely or until the checksum of the CAOM artifact is not null anymore. 

To avoid the above scenario, a CAOM artifact with a null checksum is now considered to be correct, irrespective of its contentLength or contentType. The code changes in this pull request is to implement this change.