### PR TITLE
T75931b

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.31'
+version = '2.3.32'
 
 dependencies {
     compile 'log4j:log4j:[1.2.0,)'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -229,6 +229,14 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                 if (nextLogical.contentLength == null 
                         || !nextLogical.contentLength.equals(nextPhysical.contentLength)) {
                     diffLength++;
+                    if ((nextLogical.checksum == null || nextLogical.checksum.length() == 0) 
+                            && supportSkipURITable && nextPhysical.checksum != null) {
+                        if (checkAddToSkipTable(nextLogical, "different contentLengths")) {
+                            skipURICount++;
+                        } else {
+                            inSkipURICount++;
+                        }
+                    }
                     logJSON(new String[]
                         {"logType", "detail",
                          "anomaly", "diffLength",
@@ -264,7 +272,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                 } else {
                     diffChecksum++;
                     if (supportSkipURITable && nextLogical.checksum != null && nextPhysical.checksum != null) {
-                        if (checkAddToSkipTable(nextLogical, null)) {
+                        if (checkAddToSkipTable(nextLogical, "different checksums")) {
                             skipURICount++;
                         } else {
                             inSkipURICount++;

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -231,7 +231,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                     diffLength++;
                     if ((nextLogical.checksum == null || nextLogical.checksum.length() == 0) 
                             && supportSkipURITable && nextPhysical.checksum != null) {
-                        if (checkAddToSkipTable(nextLogical, "different contentLengths")) {
+                        if (checkAddToSkipTable(nextLogical, "contentLengths are different")) {
                             skipURICount++;
                         } else {
                             inSkipURICount++;
@@ -272,7 +272,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                 } else {
                     diffChecksum++;
                     if (supportSkipURITable && nextLogical.checksum != null && nextPhysical.checksum != null) {
-                        if (checkAddToSkipTable(nextLogical, "different checksums")) {
+                        if (checkAddToSkipTable(nextLogical, "checksums are different")) {
                             skipURICount++;
                         } else {
                             inSkipURICount++;

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -256,17 +256,17 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                             }
                         }
                         logJSON(new String[]
-                                {"logType", "detail",
-                                 "anomaly", "diffLength",
-                                 "observationID", nextLogical.observationID,
-                                 "artifactURI", nextLogical.artifactURI.toString(),
-                                 "storageID", nextLogical.storageID,
-                                 "caomContentLength", nextLogical.contentLength,
-                                 "storageContentLength", nextPhysical.contentLength,
-                                 "caomCollection", collection,
-                                 "caomLastModified", logicalicalLastModified,
-                                 "ingestDate", physicalLastModified},
-                                false);
+                            {"logType", "detail",
+                             "anomaly", "diffLength",
+                             "observationID", nextLogical.observationID,
+                             "artifactURI", nextLogical.artifactURI.toString(),
+                             "storageID", nextLogical.storageID,
+                             "caomContentLength", nextLogical.contentLength,
+                             "storageContentLength", nextPhysical.contentLength,
+                             "caomCollection", collection,
+                             "caomLastModified", logicalicalLastModified,
+                             "ingestDate", physicalLastModified},
+                            false);
                     }
                 } else {
                     // checksum mismatch
@@ -279,19 +279,19 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                         }
                     }
                     logJSON(new String[]
-                            {"logType", "detail",
-                             "anomaly", "diffChecksum",
-                             "observationID", nextLogical.observationID,
-                             "artifactURI", nextLogical.artifactURI.toString(),
-                             "storageID", nextLogical.storageID,
-                             "caomChecksum", nextLogical.checksum,
-                             "caomSize", nextLogical.contentLength,
-                             "storageChecksum", nextPhysical.checksum,
-                             "storageSize", nextPhysical.contentLength,
-                             "caomCollection", collection,
-                             "caomLastModified", logicalicalLastModified,
-                             "ingestDate", physicalLastModified},
-                            false);
+                        {"logType", "detail",
+                         "anomaly", "diffChecksum",
+                         "observationID", nextLogical.observationID,
+                         "artifactURI", nextLogical.artifactURI.toString(),
+                         "storageID", nextLogical.storageID,
+                         "caomChecksum", nextLogical.checksum,
+                         "caomSize", nextLogical.contentLength,
+                         "storageChecksum", nextPhysical.checksum,
+                         "storageSize", nextPhysical.contentLength,
+                         "caomCollection", collection,
+                         "caomLastModified", logicalicalLastModified,
+                         "ingestDate", physicalLastModified},
+                        false);
                 }
             } else {
                 notInLogical++;


### PR DESCRIPTION
Updated the artifact comparison algorithm which compares a CAOM (logical) artifact with a storage (physical) artifact to account for null or empty checksum/contentLength/contentType in a logical artifact. Also we now insert an entry into the skip table on contentLength mismatches.