### PR TITLE
T75931d - artifact-discover related changes

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.32'
+version = '2.3.33'
 
 dependencies {
     compile 'log4j:log4j:[1.2.0,)'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -120,8 +120,8 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
     private String storageChecksum;
     private String caomContentLength;
     private long storageContentLength;
-	private String reason = "None";
-	private String errorMessage;
+    private String reason = "None";
+    private String errorMessage;
     
     
     // reset each run
@@ -229,14 +229,14 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                                     }
                                     
                                     try {
-                                    	// by default, do not add to the skip table
-                                    	boolean correctCopy = true;
-                                    	
-                                    	// artifact is not in storage if storage policy is 'PUBLIC ONLY' and the artifact is proprietary
+                                        // by default, do not add to the skip table
+                                        boolean correctCopy = true;
+
+                                        // artifact is not in storage if storage policy is 'PUBLIC ONLY' and the artifact is proprietary
                                         if ((StoragePolicy.ALL == storagePolicy) || errorMessage == null) {
-                                        	// correctCopy is false if: checksum mismatch, content length mismatch or not in storage
-                                        	// "not in storage" includes failing to resolve the artifact URI
-                                        	correctCopy = checkArtifactInStorage(artifact.getURI(), artifact.contentChecksum, artifact.contentLength);
+                                            // correctCopy is false if: checksum mismatch, content length mismatch or not in storage
+                                            // "not in storage" includes failing to resolve the artifact URI
+                                            correctCopy = checkArtifactInStorage(artifact.getURI(), artifact.contentChecksum, artifact.contentLength);
                                             log.debug("Artifact " + artifact.getURI() + " with MD5 " + artifact
                                                 .contentChecksum + " correct copy: " + correctCopy);
                                         }
@@ -258,11 +258,11 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                                                     message = "Public artifact already exists in skip table.";
                                                 }
                                             }
-                                        	
+
                                             if (addToSkip) {
-	                                            harvestSkipURIDAO.put(skip);
-	                                            downloadCount++;
-	                                            added = true;
+                                                harvestSkipURIDAO.put(skip);
+                                                downloadCount++;
+                                                added = true;
                                             }
                                         }
                                     } catch (Exception ex) {
@@ -297,57 +297,55 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
     }
     
     private boolean checkContentLength(HttpDownload httpHead, Long contentLength) {
-    	// no contentLength in a CAOM artifact is considered a match
-    	if (contentLength == null) {
-    		caomContentLength = "null";
-    		return true;
-    	} else if (contentLength == 0) {
-    		caomContentLength = Long.toString(contentLength);
-    		return true;
-    	} else {
-    		caomContentLength = Long.toString(contentLength);
-    		storageContentLength = httpHead.getContentLength();
-    		if (storageContentLength == contentLength) {
-    			return true;
-    		} else {
-            	reason = "ContentLengths are different";
-            	errorMessage = reason;
-            	return false;
-    		}
-    	}
-    	
-
+        // no contentLength in a CAOM artifact is considered a match
+        if (contentLength == null) {
+            caomContentLength = "null";
+            return true;
+        } else if (contentLength == 0) {
+            caomContentLength = Long.toString(contentLength);
+            return true;
+        } else {
+            caomContentLength = Long.toString(contentLength);
+            storageContentLength = httpHead.getContentLength();
+            if (storageContentLength == contentLength) {
+                return true;
+            } else {
+                reason = "ContentLengths are different";
+                errorMessage = reason;
+                return false;
+            }
+        }
     }
     
     private boolean checkChecksum(HttpDownload httpHead, URI checksum) {       
         String expectedMD5 = artifactStore.getMD5Sum(checksum);
         log.debug("Expected MD5: " + expectedMD5);
         if (expectedMD5 == null) {
-    		// no checksum in a CAOM artifact is considered a match
-        	reason = "Null checksum";
-        	caomChecksum = "null";
-        	return true;
+            // no checksum in a CAOM artifact is considered a match
+            reason = "Null checksum";
+            caomChecksum = "null";
+            return true;
         } else {
-        	caomChecksum = expectedMD5;
+            caomChecksum = expectedMD5;
         }
         
         String contentMD5 = httpHead.getContentMD5();
         log.debug("Found matching artifact with md5 " + contentMD5);
         storageChecksum = contentMD5;
         if (expectedMD5.equalsIgnoreCase(contentMD5)) {
-        	return true;
+            return true;
         } else {
-        	reason = "Checksums are different";
-        	errorMessage = reason;
-        	return false;
+            reason = "Checksums are different";
+            errorMessage = reason;
+            return false;
         }
     }
     
     private boolean checkArtifactInStorage(URI artifactURI, URI checksum, Long contentLength) throws TransientException {
         URL url = artifactStore.resolveURI(artifactURI);
         if (url == null) {
-        	reason = "Could not resolve artifact URI";
-        	errorMessage = reason;
+            reason = "Could not resolve artifact URI";
+            errorMessage = reason;
             log.debug("Failed to resolve artifact URI: " + artifactURI);
             return false;
         }
@@ -357,9 +355,9 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
         log.debug("Response code: " + respCode);
         if (httpHead.getThrowable() == null && respCode == 200) {
             if (checkChecksum(httpHead, checksum)) {
-            	return checkContentLength(httpHead, contentLength);
+                return checkContentLength(httpHead, contentLength);
             } else {
-            	return false;
+                return false;
             }
         }
 

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -102,7 +102,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
 
     public static final Integer DEFAULT_BATCH_SIZE = Integer.valueOf(1000);
     public static final String STATE_CLASS = Artifact.class.getSimpleName();
-    public static final String PROPRIETARY = "proprietary";
+    public static final String PROPRIETARY = "Proprietary";
 
     private static final Logger log = Logger.getLogger(ArtifactHarvester.class);
 
@@ -248,12 +248,14 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                                                 skip = new HarvestSkipURI(source, STATE_CLASS, artifact.getURI(), releaseDate, errorMessage);
                                                 addToSkip = true;
                                             } else {
-                                                message = "Artifact already exists in skip table.";
                                                 if (errorMessage == ArtifactHarvester.PROPRIETARY) {
                                                     // artifact is private, update skip table
+                                                    message = errorMessage + " artifact already exists in skip table.";
                                                     skip.setTryAfter(releaseDate);
                                                     skip.errorMessage = errorMessage;
                                                     addToSkip = true;
+                                                } else {
+                                                    message = "Public artifact already exists in skip table.";
                                                 }
                                             }
                                         	
@@ -308,7 +310,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
     		if (storageContentLength == contentLength) {
     			return true;
     		} else {
-            	reason = "contentLengths are different";
+            	reason = "ContentLengths are different";
             	errorMessage = reason;
             	return false;
     		}
@@ -322,7 +324,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
         log.debug("Expected MD5: " + expectedMD5);
         if (expectedMD5 == null) {
     		// no checksum in a CAOM artifact is considered a match
-        	reason = "null checksum";
+        	reason = "Null checksum";
         	caomChecksum = "null";
         	return true;
         } else {
@@ -335,7 +337,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
         if (expectedMD5.equalsIgnoreCase(contentMD5)) {
         	return true;
         } else {
-        	reason = "checksums are different";
+        	reason = "Checksums are different";
         	errorMessage = reason;
         	return false;
         }
@@ -344,7 +346,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
     private boolean checkArtifactInStorage(URI artifactURI, URI checksum, Long contentLength) throws TransientException {
         URL url = artifactStore.resolveURI(artifactURI);
         if (url == null) {
-        	reason = "could not resolve artifact URI";
+        	reason = "Could not resolve artifact URI";
         	errorMessage = reason;
             log.debug("Failed to resolve artifact URI: " + artifactURI);
             return false;
@@ -363,7 +365,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
 
         if (httpHead.getResponseCode() == 404) {
             log.debug("Artifact not found");
-            reason = "artifact not in storage";
+            reason = "Artifact not in storage";
             errorMessage = reason;
             return false;
         }
@@ -371,7 +373,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
         // redirects mean that a copy isn't local
         if (httpHead.getResponseCode() == 303 || httpHead.getResponseCode() == 302) {
             log.debug("Redirected to another source");
-            reason = "artifact not in local storage";
+            reason = "Artifact not in local storage";
             errorMessage = reason;
             return false;
         }
@@ -379,15 +381,15 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
         if (httpHead.getThrowable() != null) {
             if (httpHead.getThrowable() instanceof TransientException) {
                 log.debug("Transient Exception");
-                reason = "transient exception: " + httpHead.getThrowable().getMessage();
+                reason = "Transient exception: " + httpHead.getThrowable().getMessage();
                 throw (TransientException) httpHead.getThrowable();
             }
 
-            reason = "unexpected exception: " + httpHead.getThrowable().getMessage();
+            reason = "Unexpected exception: " + httpHead.getThrowable().getMessage();
             throw new RuntimeException("Unexpected", httpHead.getThrowable());
         }
 
-        reason = "unexpected response code: " + respCode;
+        reason = "Unexpected response code: " + respCode;
         throw new RuntimeException("unexpected response code " + respCode);
     }
     
@@ -432,7 +434,6 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
         startMessage.append("\"storageContentLength\":\"").append(storageContentLength).append("\"");
         startMessage.append(",");
         startMessage.append("\"collection\":\"").append(collection).append("\"");
-        startMessage.append(",");
         if (message != null) {
             startMessage.append(",");
             startMessage.append("\"message\":\"").append(message).append("\"");

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -249,7 +249,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                         // content length mismatch
                         diffLength++;
                         if (supportSkipURITable) {
-                            if (checkAddToSkipTable(nextLogical, "contentLengths are different")) {
+                            if (checkAddToSkipTable(nextLogical, "ContentLengths are different")) {
                                 skipURICount++;
                             } else {
                                 inSkipURICount++;
@@ -272,7 +272,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
                     // checksum mismatch
                     diffChecksum++;
                     if (supportSkipURITable) {
-                        if (checkAddToSkipTable(nextLogical, "checksums are different")) {
+                        if (checkAddToSkipTable(nextLogical, "Checksums are different")) {
                             skipURICount++;
                         } else {
                             inSkipURICount++;

--- a/caom2-artifact-sync/src/test/java/ca/nrc/cadc/caom2/artifactsync/ArtifactMetadataTest.java
+++ b/caom2-artifact-sync/src/test/java/ca/nrc/cadc/caom2/artifactsync/ArtifactMetadataTest.java
@@ -73,17 +73,15 @@ import ca.nrc.cadc.caom2.ReleaseType;
 import ca.nrc.cadc.caom2.artifact.ArtifactMetadata;
 import ca.nrc.cadc.caom2.artifact.ArtifactStore;
 import ca.nrc.cadc.caom2.artifact.StoragePolicy;
-import ca.nrc.cadc.caom2.artifact.resolvers.CaomArtifactResolver;
+import ca.nrc.cadc.net.HttpDownload;
 import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.util.FileMetadata;
-import ca.nrc.cadc.util.PropertiesReader;
 
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.security.AccessControlException;
 import java.util.Date;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -208,6 +206,21 @@ public class ArtifactMetadataTest
         }
 
         public boolean contains(URI artifactURI, URI checksum) throws TransientException {
+            // not used by the unit test
+            throw new UnsupportedOperationException("This method should not have been invoked.");
+        }
+
+        public HttpDownload downloadHeader(URL artifactURI) throws IllegalArgumentException {
+            // not used by the unit test
+            throw new UnsupportedOperationException("This method should not have been invoked.");
+        }
+
+        public URL resolveURI(URI artifactURI) throws IllegalArgumentException {
+            // not used by the unit test
+            throw new UnsupportedOperationException("This method should not have been invoked.");
+        }
+
+        public String getMD5Sum(URI checksum) throws UnsupportedOperationException {
             // not used by the unit test
             throw new UnsupportedOperationException("This method should not have been invoked.");
         }

--- a/caom2-persist/build.gradle
+++ b/caom2-persist/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.10'
+version = '2.3.11'
 
 dependencies {
     compile 'log4j:log4j:[1.2.+,)'

--- a/caom2-persist/src/main/java/ca/nrc/cadc/caom2/artifact/ArtifactStore.java
+++ b/caom2-persist/src/main/java/ca/nrc/cadc/caom2/artifact/ArtifactStore.java
@@ -139,16 +139,16 @@ public interface ArtifactStore {
     public URL resolveURI(URI artifactURI)
             throws IllegalArgumentException;
 
-   /**
-    * @param checksum
-    *            The checksum of the artifact.
-    * @return the MD5 checksum.
-    *
-    * @throws UnsupportedOperationException
-    *             If the artifact uri cannot be resolved.
-    */
+    /**
+     * @param checksum
+     *            The checksum of the artifact.
+     * @return the MD5 checksum.
+     *
+     * @throws UnsupportedOperationException
+     *             If the artifact uri cannot be resolved.
+     */
     public String getMD5Sum(URI checksum)
-    		throws UnsupportedOperationException;
+            throws UnsupportedOperationException;
 
     /**
      * Get the storage policy based on the collection provided.

--- a/caom2-persist/src/main/java/ca/nrc/cadc/caom2/artifact/ArtifactStore.java
+++ b/caom2-persist/src/main/java/ca/nrc/cadc/caom2/artifact/ArtifactStore.java
@@ -69,11 +69,13 @@
 
 package ca.nrc.cadc.caom2.artifact;
 
+import ca.nrc.cadc.net.HttpDownload;
 import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.util.FileMetadata;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URL;
 import java.security.AccessControlException;
 import java.util.Set;
 
@@ -108,6 +110,45 @@ public interface ArtifactStore {
      */
     public boolean contains(URI artifactURI, URI checksum)
             throws TransientException, UnsupportedOperationException, IllegalArgumentException, AccessControlException, IllegalStateException;
+
+    /**
+     * Get a header containing information, e.g. Content-Length, checksum, of the specified artifact.
+     *
+     * @param artifactURL
+     *            The URL of the artifact in storage.
+     * @return HttpDownload instance with header containing information on the artifact in storage.
+     *
+     * @throws IllegalArgumentException
+     *             If an aspect of the artifact uri is incorrect.
+     * @throws AccessControlException
+     *             If the calling user is not allowed to perform the query.
+     */
+    public HttpDownload downloadHeader(URL artifactURL)
+            throws IllegalArgumentException, AccessControlException;
+    
+    /**
+     * Get a header containing information, e.g. Content-Length, checksum, of the specified artifact.
+     *
+     * @param artifactURI
+     *            The artifact identifier.
+     * @return URL of the artifact or null if the URI does not resolve to a URL.
+     *
+     * @throws IllegalArgumentException
+     *             If an aspect of the artifact uri is incorrect.
+     */
+    public URL resolveURI(URI artifactURI)
+            throws IllegalArgumentException;
+
+   /**
+    * @param checksum
+    *            The checksum of the artifact.
+    * @return the MD5 checksum.
+    *
+    * @throws UnsupportedOperationException
+    *             If the artifact uri cannot be resolved.
+    */
+    public String getMD5Sum(URI checksum)
+    		throws UnsupportedOperationException;
 
     /**
      * Get the storage policy based on the collection provided.


### PR DESCRIPTION
We want to provide more information in artifact-discover log. The information to be provided is similar to those provided in artifact-validate log. To do that, we need to access the information available inside ArtifactStore.contains(). Hence several methods are added the ArtifactStore API. 