### PR TITLE
Change dependencies with "plus" to maven compliant syntax.

### DIFF
--- a/caom2-access-control/build.gradle
+++ b/caom2-access-control/build.gradle
@@ -15,10 +15,10 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.3'
+version = '2.3.4'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
+    compile 'log4j:log4j:[1.2,1.3)'
     
     compile 'org.opencadc:cadc-util:[1.2.3,2.0)'
     compile 'org.opencadc:cadc-log:[1.0,)'

--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.33'
+version = '2.3.34'
 
 dependencies {
     compile 'log4j:log4j:[1.2.0,)'
@@ -34,7 +34,7 @@ dependencies {
     runtime 'net.sourceforge.jtds:jtds:[1.0,)'
     runtime 'org.postgresql:postgresql:9.4.1209.jre7'
     
-    testCompile 'junit:junit:[4.+,)'
+    testCompile 'junit:junit:[4,)'
 }
 
 apply from: '../opencadc.gradle'

--- a/caom2-persist/build.gradle
+++ b/caom2-persist/build.gradle
@@ -15,15 +15,15 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.11'
+version = '2.3.12'
 
 dependencies {
-    compile 'log4j:log4j:[1.2.+,)'
+    compile 'log4j:log4j:[1.2,)'
     
-    compile 'org.opencadc:cadc-util:[1.+,)'
+    compile 'org.opencadc:cadc-util:[1,)'
     compile 'org.opencadc:caom2:[2.3.13,2.4)'
 
-    testCompile 'junit:junit:[4.+,)'
+    testCompile 'junit:junit:[4,)'
 }
 
 apply from: '../opencadc.gradle'

--- a/caom2-remove/build.gradle
+++ b/caom2-remove/build.gradle
@@ -18,19 +18,19 @@ group = 'org.opencadc'
 
 mainClassName = 'ca.nrc.cadc.caom2.remove.Main'
 
-version = '1.1'
+version = '1.1.1'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
-    compile 'org.jdom:jdom2:2.+'
+    compile 'log4j:log4j:[1.2,1.3)'
+    compile 'org.jdom:jdom2:[2,3)'
     compile 'org.springframework:spring-jdbc:2.5.6.SEC01'
 
     compile 'org.opencadc:caom2persistence:[2.3.30,)'
 
-    runtime 'net.sourceforge.jtds:jtds:1.+'
+    runtime 'net.sourceforge.jtds:jtds:[1,2)'
     runtime 'org.postgresql:postgresql:9.4.1209.jre7'
     
-    testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4,5)'
 }
 
 apply from: '../opencadc.gradle'

--- a/caom2-repo/build.gradle
+++ b/caom2-repo/build.gradle
@@ -16,14 +16,14 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.3.1'
+version = '1.3.2'
 
 mainClassName = 'ca.nrc.cadc.caom2.repo.client.Main'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
-    compile 'net.sourceforge.javacsv:javacsv:2.+'
-    compile 'javax.servlet:javax.servlet-api:3.1.+'
+    compile 'log4j:log4j:[1.2,1.3)'
+    compile 'net.sourceforge.javacsv:javacsv:[2,3)'
+    compile 'javax.servlet:javax.servlet-api:[3.1,3.2)'
     
     compile 'org.opencadc:cadc-util:[1.0.14,)'
     compile 'org.opencadc:caom2:[2.3.9,2.4)'
@@ -33,7 +33,7 @@ dependencies {
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
 
     
-    testCompile 'junit:junit:4.+'
+    testCompile 'junit:junit:[4,5)'
     testCompile 'org.easymock:easymock:[3.2,4.0)'
 }
 

--- a/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
+++ b/caom2harvester/src/main/java/ca/nrc/cadc/caom2/harvester/Main.java
@@ -419,7 +419,8 @@ public class Main {
             sb.append("\n\nSource selection:");
             sb.append("\n          <server.database.schema> : the server and database connection info will be found in $HOME/.dbrc");
             sb.append("\n          <resourceID> : resource identifier for a registered caom2 repository service (e.g. ivo://cadc.nrc.ca/ams)");
-            sb.append("\n          <capabilities URL> : direct URL to a VOSI capabilities document with caom2 repository endpoints (use: unregistered service)");
+            sb.append("\n          <capabilities URL> : direct URL to a VOSI capabilities document with caom2 repository "
+                    + "endpoints (use: unregistered service)");
             sb.append("\n         [--threads=<num threads>] : number  of threads used to read observation documents (service only, default: 1)");
         }
 

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -18,12 +18,12 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.35'
+version = '2.3.36'
 
 mainClassName = 'ca.nrc.cadc.caom2.version.Main'
 
 dependencies {
-    compile 'log4j:log4j:1.2.+'
+    compile 'log4j:log4j:[1.2,1.3)'
     compile 'org.springframework:spring-jdbc:2.5.6.SEC01'
     compile 'org.postgresql:postgresql:9.4.1209.jre7'
     
@@ -36,7 +36,7 @@ dependencies {
     testCompile 'junit:junit:4.+'
     
     // JDBC drivers
-    intTestRuntime 'net.sourceforge.jtds:jtds:1.+'
+    intTestRuntime 'net.sourceforge.jtds:jtds:[1,2)'
     intTestRuntime 'org.postgresql:postgresql:9.4.1209.jre7'
 }
 

--- a/opencadc.gradle
+++ b/opencadc.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     testCompile 'com.puppycrawl.tools:checkstyle:8.2'
-    checkstyleDep 'org.opencadc:cadc-quality:1.+'
+    checkstyleDep 'org.opencadc:cadc-quality:[1,2)'
 }
 
 checkstyle {


### PR DESCRIPTION
ESDC is migrating all its projects to Maven. In this process it has been found that some dependencies from CADC CAOM software are failing due to dependencies defined with a plus sign ("+"). In this branch, all this kind of dependencies has been changed to a maven valid syntax. For instance:
From:
compile 'log4j:log4j:1.2.+'
To:
compile 'log4j:log4j:[1.2,1.3)'