### PR TITLE
Allowing file sync to work with caom 2.4

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.3.38'
+version = '2.4.0'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'
@@ -24,9 +24,9 @@ dependencies {
 
     compile 'org.opencadc:cadc-util:[1.2.3,1.3)'
     compile 'org.opencadc:cadc-registry:[1.5,1.6)'
-    compile 'org.opencadc:caom2:[2.3,2.4)'
-    compile 'org.opencadc:caom2-persist:[2.3.7,2.4)'
-    compile 'org.opencadc:caom2persistence:[2.3.19,2.4)'
+    compile 'org.opencadc:caom2:[2.4,2.5)'
+    compile 'org.opencadc:caom2-persist:[2.4,2.5)'
+    compile 'org.opencadc:caom2persistence:[2.4,2.5)'
     compile 'org.opencadc:caom2-artifact-resolvers:[1.1.11,1.2)'
     compile 'org.opencadc:cadc-tap:[1.0,1.1)'
 

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -183,7 +183,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                         log.debug("harvesState: " + format(state.curID) + ", " + this.df.format(state.curLastModified));
                     }
                     if (curBatchLeader.getMaxLastModified().equals(state.curLastModified)) {
-                        Observation observation = this.observationDAO.get(curBatchLeader.getURI());
+                        Observation observation = this.observationDAO.get(curBatchLeader.getID());
                         log.debug("current batch: " + format(observation.getID()) + ", " + this.df.format(curBatchLeader.getMaxLastModified()));
                         if (state.curID != null && state.curID.equals(observation.getID())) {
                             iter.remove();
@@ -198,7 +198,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
 
                 try {
                     this.observationDAO.getTransactionManager().startTransaction();
-                    Observation observation = this.observationDAO.get(observationState.getURI());
+                    Observation observation = this.observationDAO.get(observationState.getID());
                     
                     if (observation == null) {
                         log.debug("Observation no longer exists: " + observationState.getURI());

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -495,7 +495,7 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
             while (iter.hasNext()) {
                 ObservationState s = iter.next();
                 iter.remove(); // GC
-                ObservationResponse resp = observationDAO.getAlt(s, depth);
+                ObservationResponse resp = observationDAO.getObservationResponse(s, depth);
                 if (resp == null) {
                     log.error("Null response from Observation DAO, ObservationURI: " + s.getURI().toString() + ", depth: " + depth);
                 } else if (resp.observation == null) {

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.2'
+version = '2.4.3'
 
 mainClassName = 'ca.nrc.cadc.caom2.version.Main'
 

--- a/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/SQLGenerator.java
+++ b/caom2persistence/src/main/java/ca/nrc/cadc/caom2/persistence/SQLGenerator.java
@@ -577,7 +577,7 @@ public class SQLGenerator {
         columnMap.put(PartSkeleton.class, new String[]{"lastModified", "maxLastModified", "metaChecksum", "accMetaChecksum", "partID"});
         columnMap.put(ChunkSkeleton.class, new String[]{"lastModified", "maxLastModified", "metaChecksum", "accMetaChecksum", "chunkID"});
 
-        columnMap.put(ObservationState.class, new String[]{"collection", "observationID", "maxLastModified", "accMetaChecksum"});
+        columnMap.put(ObservationState.class, new String[]{"collection", "observationID", "maxLastModified", "accMetaChecksum", "obsID"});
     }
 
     private String[] addExtraColumns(String[] origCols, String[] extraCols) {
@@ -3983,6 +3983,8 @@ public class SQLGenerator {
 
             ret.maxLastModified = Util.getDate(rs, col++, utcCalendar);
             ret.accMetaChecksum = Util.getURI(rs, col++);
+            
+            ret.id = Util.getUUID(rs, col++);
 
             return ret;
         }


### PR DESCRIPTION
Modified both caom2-artifact-sync and caom2persistance to allow ObservationState retrieval to include obsID