### PR TITLE
T75729 - to provide a version option to caom2-artifact-sync

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.0'
+version = '2.4.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'

--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -37,3 +37,10 @@ dependencies {
 }
 
 apply from: '../opencadc.gradle'
+
+jar {
+    doFirst {
+        mkdir "build/resources/main"
+        new File("build/resources/main", "artifact-sync.properties").text = """Version = $version"""
+    }
+}

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2Version.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2Version.java
@@ -76,7 +76,7 @@ import org.apache.log4j.Logger;
 /**
  * A class to provide a method to obtain the version of the 
  * artifact-sync service. The version resides in the version.properties
- * file as a key/value pair, i.e. Version=<version>.
+ * file as a key/value pair, i.e. Version=<build version>.
  *
  * @author yeunga
  */

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2Version.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2Version.java
@@ -92,7 +92,7 @@ public class Caom2Version {
         if (values != null) {
             return values.get(0);
         } else {
-                return null;
+            return null;
         }
     }
 }

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2Version.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2Version.java
@@ -76,7 +76,7 @@ import org.apache.log4j.Logger;
 /**
  * A class to provide a method to obtain the version of the 
  * artifact-sync service. The version resides in the version.properties
- * file as a key/value pair, i.e. Version=<build version>.
+ * file as a key/value pair.
  *
  * @author yeunga
  */

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ClientVersion.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ClientVersion.java
@@ -69,30 +69,47 @@
 
 package ca.nrc.cadc.caom2.artifactsync;
 
-import ca.nrc.cadc.util.PropertiesReader;
+import ca.nrc.cadc.util.FileUtil;
+import ca.nrc.cadc.util.MultiValuedProperties;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import org.apache.log4j.Logger;
 
 /**
- * A class to provide a method to obtain the version of the 
- * artifact-sync service. The version resides in the version.properties
+ * A class to provide a method to obtain the version of an 
+ * application. The version resides in the properties
  * file as a key/value pair.
  *
  * @author yeunga
  */
-public class Caom2Version {
+public class ClientVersion {
 
-    private static Logger log = Logger.getLogger(Caom2Version.class);
+    private static Logger log = Logger.getLogger(ClientVersion.class);
     private static final String VERSION_KEY = "Version";
-    private static final String VERSION_CONFIG = "version.properties";
-
-    public static String getVersion() {
-        PropertiesReader pr = new PropertiesReader(VERSION_CONFIG);
-        List<String> values = pr.getPropertyValues(VERSION_KEY);
-        if (values != null) {
-            return values.get(0);
-        } else {
-            return null;
+    
+    public static String getVersion(String filename) {
+        MultiValuedProperties properties = null;
+    	File versionFile = FileUtil.getFileFromResource(filename, Caom2ArtifactSync.class);
+        try {
+            InputStream in = new FileInputStream(versionFile);
+            properties = new MultiValuedProperties();
+            properties.load(in);
+        } catch (IOException e) {
+            // File could not be opened
+            properties = null;
         }
+
+        if (properties != null) {
+            List<String> values = properties.getProperty(VERSION_KEY);
+            if (values != null && values.size() > 0) {
+                return values.get(0);
+            }
+        }
+        
+        return null;
     }
 }

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Discover.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Discover.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2018.                            (c) 2018.
+*  (c) 2020.                            (c) 2020.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Discover.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Discover.java
@@ -188,6 +188,7 @@ public class Discover extends Caom2ArtifactSync {
             sb.append("\n        --batchsize=<integer> Max observations to check (default: 1000)");
         }
         sb.append("\n\n    optional general args:");
+        sb.append("\n        -V | --version");
         sb.append("\n        -v | --verbose");
         sb.append("\n        -d | --debug");
         sb.append("\n        -h | --help");

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Main.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Main.java
@@ -85,6 +85,7 @@ import org.apache.log4j.Logger;
 public class Main {
 
     private static Logger log = Logger.getLogger(Main.class);
+    private static String VERSION_FILENAME = "artifact-sync.properties";
     private static Caom2ArtifactSync command;
 
     public static void main(String[] args) {
@@ -134,7 +135,7 @@ public class Main {
 
     private static void printVersion() {
         // get the version of artifact-sync service
-        String version = Caom2Version.getVersion();
+        String version = ClientVersion.getVersion(VERSION_FILENAME);
         if (version == null) {
             log.info("no version information available");
         } else {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Main.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Main.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2018.                            (c) 2018.
+*  (c) 2020.                            (c) 2020.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -96,6 +96,8 @@ public class Main {
                 if (am.isSet("h") || am.isSet("help")) {
                     // help on caom2-artifact-sync
                     printUsage();
+                } else if (am.isSet("V") || am.isSet("version")) {
+                    printVersion();
                 } else {
                     String msg = "Missing a valid mode: discover, download, validate, diff.";
                     exitWithErrorUsage(msg);
@@ -105,13 +107,7 @@ public class Main {
                 exitWithErrorUsage(msg);
             } else {
                 if (am.isSet("V") || am.isSet("version")) {
-                    // get the version of artifact-sync service
-                    String version = Caom2Version.getVersion();
-                    if (version == null) {
-                        log.info("no version information available");
-                    } else {
-                        log.info(version);
-                    }
+                    printVersion();
                 } else {
                     // one mode is specified
                     String mode = positionalArgs.get(0);
@@ -136,6 +132,16 @@ public class Main {
         }
     }
 
+    private static void printVersion() {
+        // get the version of artifact-sync service
+        String version = Caom2Version.getVersion();
+        if (version == null) {
+            log.info("no version information available");
+        } else {
+            log.info(version);
+        }
+    }
+
     private static void printUsage() {
         StringBuilder sb = new StringBuilder();
         sb.append("\n\nusage: ").append(Caom2ArtifactSync.getApplicationName()).append(" <mode> [mode-args] --artifactStore=<fully qualified class name>");
@@ -146,6 +152,7 @@ public class Main {
         sb.append("\n        validate: Discover missing artifacts and update the HarvestSkipURI table");
         sb.append("\n        diff: Discover and report missing artifacts");
         sb.append("\n\n    optional general args:");
+        sb.append("\n        -V | --version");
         sb.append("\n        -v | --verbose");
         sb.append("\n        -d | --debug");
         sb.append("\n        -h | --help");

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Validate.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Validate.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2018.                            (c) 2018.
+*  (c) 2020.                            (c) 2020.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Validate.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Validate.java
@@ -156,6 +156,7 @@ public class Validate extends Caom2ArtifactSync {
             sb.append("\n        --collection=<collection> : The collection to validate");
         }
         sb.append("\n\n    optional general args:");
+        sb.append("\n        -V | --version");
         sb.append("\n        -v | --verbose");
         sb.append("\n        -d | --debug");
         sb.append("\n        -h | --help");


### PR DESCRIPTION
A version.properties file containing the current version (e.g. Version=2.4.1) of the service can be generated during build and stored in <user>/config/. A -V | --version option can be used to print the version as read from the version.properties file.