### PR TITLE
Close version ranges in dependencies.

### DIFF
--- a/caom2-repo-server/build.gradle
+++ b/caom2-repo-server/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
     compile 'org.opencadc:cadc-rest:[1.2.13,2.0)'
     compile 'org.opencadc:cadc-uws-server:[1.2,1.3)'
-    compile 'org.opencadc:cadc-permissions:[0.1,0.2)'
+    compile 'org.opencadc:cadc-permissions:[0.2,0.3)'
     
     // support optional computeMetadata
     compile 'org.opencadc:caom2-compute:[2.4.0,2.5)'

--- a/caom2-repo-server/build.gradle
+++ b/caom2-repo-server/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.5'
+version = '2.4.6'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'
@@ -33,7 +33,7 @@ dependencies {
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
     compile 'org.opencadc:cadc-rest:[1.2.13,2.0)'
     compile 'org.opencadc:cadc-uws-server:[1.2,1.3)'
-    compile 'org.opencadc:cadc-permissions:[0.1,)'
+    compile 'org.opencadc:cadc-permissions:[0.1,0.2)'
     
     // support optional computeMetadata
     compile 'org.opencadc:caom2-compute:[2.4.0,2.5)'

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.4'
+version = '2.4.5'
 
 mainClassName = 'ca.nrc.cadc.caom2.version.Main'
 
@@ -27,9 +27,9 @@ dependencies {
     compile 'org.springframework:spring-jdbc:2.5.6.SEC01'
     compile 'org.postgresql:postgresql:9.4.1209.jre7'
     
-    compile 'org.opencadc:cadc-util:[1.1.5,)'
-    compile 'org.opencadc:cadc-dali:[1.1,)'
-    compile 'org.opencadc:cadc-dali-pg:[0.1,)'
+    compile 'org.opencadc:cadc-util:[1.1.5,1.2)'
+    compile 'org.opencadc:cadc-dali:[1.1,1.2)'
+    compile 'org.opencadc:cadc-dali-pg:[0.1,0.2)'
     compile 'org.opencadc:caom2:[2.4.3,2.5)'
     compile 'org.opencadc:caom2-persist:[2.4.0,2.5)'
 

--- a/caom2persistence/build.gradle
+++ b/caom2persistence/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.springframework:spring-jdbc:2.5.6.SEC01'
     compile 'org.postgresql:postgresql:9.4.1209.jre7'
     
-    compile 'org.opencadc:cadc-util:[1.1.5,1.2)'
+    compile 'org.opencadc:cadc-util:[1.2,1.3)'
     compile 'org.opencadc:cadc-dali:[1.1,1.2)'
     compile 'org.opencadc:cadc-dali-pg:[0.1,0.2)'
     compile 'org.opencadc:caom2:[2.4.3,2.5)'


### PR DESCRIPTION
Our Maven projects fail to compile with a nasty out of memory exception when trying to resolve dependencies. Ideally, a fixed version could be used in dependencies, but at least a closed range only allowing minor versions would help. This pull request closes the open ranges found.