### PR TITLE
caom2-access-control: work-around when group update call fails in response handling

### DIFF
--- a/caom2-access-control/build.gradle
+++ b/caom2-access-control/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.3'
+version = '2.4.4'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'


### PR DESCRIPTION
The /ac/groups endpoint returns the modified group in the body, and GMSClient tries to read the body and return the Group.
caom2-access-control ignores the return, but this **sometimes** happens and causes the whole call to fail when it really succeeded:

```
Caused by: ca.nrc.cadc.ac.ReaderException: XML failed validation: Error on line 847: The element type "personalDetails" must be terminated by the matching end-tag "</personalDetails>".
        at ca.nrc.cadc.ac.xml.GroupReader.read(GroupReader.java:162)
        at ca.nrc.cadc.ac.xml.GroupReader.read(GroupReader.java:108)
        at ca.nrc.cadc.ac.client.GMSClient.updateGroup(GMSClient.java:467)
        at ca.nrc.cadc.caom2.ac.ReadAccessGenerator.checkProposalGroup(ReadAccessGenerator.java:368)
        ... 30 more
Caused by: org.jdom2.input.JDOMParseException: Error on line 847: The element type "personalDetails" must be terminated by the matching end-tag "</personalDetails>".
        at org.jdom2.input.sax.SAXBuilderEngine.build(SAXBuilderEngine.java:232)
        at org.jdom2.input.sax.SAXBuilderEngine.build(SAXBuilderEngine.java:303)
        at org.jdom2.input.SAXBuilder.build(SAXBuilder.java:1196)
        at ca.nrc.cadc.xml.XmlUtil.buildDocument(XmlUtil.java:222)
        at ca.nrc.cadc.xml.XmlUtil.buildDocument(XmlUtil.java:189)
        at ca.nrc.cadc.ac.xml.GroupReader.read(GroupReader.java:157)
        ... 33 more
```
