### PR TITLE
T76736 To improve usage of the thread pool more efficiently 

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '2.4.0'
+version = '2.4.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -95,9 +95,11 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.UUID;
 
+import javax.lang.model.type.NullType;
+
 import org.apache.log4j.Logger;
 
-public class ArtifactHarvester implements PrivilegedExceptionAction<Void>, ShutdownListener {
+public class ArtifactHarvester implements PrivilegedExceptionAction<NullType>, ShutdownListener {
 
     public static final Integer DEFAULT_BATCH_SIZE = Integer.valueOf(1000);
     public static final String STATE_CLASS = Artifact.class.getSimpleName();
@@ -151,7 +153,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Void>, Shutd
     }
 
     @Override
-    public Void run() throws Exception {
+    public NullType run() throws Exception {
         int loopNum = 1;
         boolean stop = false;
         do {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -462,8 +462,12 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Void>, Shutd
     }
     
     private void logBatchEnd() {
+        logBatchEnd("ENDBATCH");
+    }
+
+    private void logBatchEnd(String endString) {
         StringBuilder batchMessage = new StringBuilder();
-        batchMessage.append("ENDBATCH: {");
+        batchMessage.append(endString + ": {");
         batchMessage.append("\"total\":\"").append(this.processedCount).append("\"");
         batchMessage.append(",");
         batchMessage.append("\"added\":\"").append(this.downloadCount).append("\"");
@@ -477,7 +481,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Void>, Shutd
 
     @Override
     public void shutdown() {
-        logBatchEnd();
+        logBatchEnd("ENDDISCOVER");
     }
     
 }

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -97,7 +97,7 @@ import java.util.UUID;
 
 import org.apache.log4j.Logger;
 
-public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, ShutdownListener {
+public class ArtifactHarvester implements PrivilegedExceptionAction<Void>, ShutdownListener {
 
     public static final Integer DEFAULT_BATCH_SIZE = Integer.valueOf(1000);
     public static final String STATE_CLASS = Artifact.class.getSimpleName();
@@ -112,6 +112,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
     private String collection; 
     private StoragePolicy storagePolicy;
     private int batchSize;
+    private boolean loop;
     private String source;
     private Date startDate;
     private DateFormat df;
@@ -130,11 +131,12 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
     Date start = new Date();
 
     public ArtifactHarvester(ObservationDAO observationDAO, HarvestResource harvestResource,
-                             ArtifactStore artifactStore, int batchSize) {
+                             ArtifactStore artifactStore, int batchSize, boolean loop) {
 
         this.observationDAO = observationDAO;
         this.artifactStore = artifactStore;
         this.batchSize = batchSize;
+        this.loop = loop;
         this.source = harvestResource.getIdentifier();
         this.collection = harvestResource.getCollection();
         this.storagePolicy = artifactStore.getStoragePolicy(collection);
@@ -149,14 +151,32 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
     }
 
     @Override
-    public Integer run() throws Exception {
+    public Void run() throws Exception {
+        int loopNum = 1;
+        boolean stop = false;
+        do {
+            if (loop) {
+                log.info("-- STARTING LOOP #" + loopNum + " --");
+            }
+
+            stop = runIt();
+
+            if (loop) {
+                log.info("-- ENDING LOOP #" + loopNum + " --");
+            }
+
+            loopNum++;
+        } while (loop && !stop); // continue if work was done
+        
+        return null;
+    }
+    
+    private Boolean runIt() throws Exception {
 
         this.downloadCount = 0;
         this.processedCount = 0;
         this.start = new Date();
         
-        int num = 0;
-
         try {
             // Determine the state of the last run
             HarvestState state = harvestStateDAO.get(source, STATE_CLASS);
@@ -192,8 +212,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                 }
             }
 
-            num = observationStates.size();
-            log.info("Found: " + num);
+            log.info("Found: " + observationStates.size());
             for (ObservationState observationState : observationStates) {
 
                 try {
@@ -308,7 +327,7 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<Integer>, Sh
                 }
             }
 
-            return num;
+            return (observationStates.size() < batchSize + 1);
         } finally {
             logBatchEnd();
         }

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
@@ -103,9 +103,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import javax.lang.model.type.NullType;
+
 import org.apache.log4j.Logger;
 
-public class DownloadArtifactFiles implements PrivilegedExceptionAction<Void>, ShutdownListener {
+public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType>, ShutdownListener {
 
     private static final Logger log = Logger.getLogger(DownloadArtifactFiles.class);
 
@@ -152,7 +154,7 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<Void>, S
     }
 
     @Override
-    public Void run() throws Exception {
+    public NullType run() throws Exception {
 
         executor = Executors.newFixedThreadPool(threads);
         results = new ArrayList<Future<ArtifactDownloadResult>>();

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
@@ -217,7 +217,7 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<Void>, S
                 executor.shutdownNow();
             }
             executor = null;
-            logBatchEnd(results.size(), successes, totalElapsedTime, totalBytes);
+            logDownloadEnd(results.size(), successes, totalElapsedTime, totalBytes);
         }
         
         return null;
@@ -479,10 +479,10 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<Void>, S
         threadLog.info(startMessage.toString());
     }
 
-    private void logBatchEnd(long total, long successes, long totalElapsedTime, long totalBytes) {
+    private void logDownloadEnd(long total, long successes, long totalElapsedTime, long totalBytes) {
         final long end = System.currentTimeMillis() - start;
         StringBuilder endMessage = new StringBuilder();
-        endMessage.append("ENDBATCH: {");
+        endMessage.append("ENDDOWNLOAD: {");
         endMessage.append("\"total\":\"").append(total).append("\"");
         endMessage.append(",");
         endMessage.append("\"successCount\":\"").append(successes).append("\"");
@@ -511,7 +511,7 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<Void>, S
 
             if (results == null) {
                 StringBuilder endMessage = new StringBuilder();
-                endMessage.append("ENDBATCH: {");
+                endMessage.append("ENDDOWNLOAD: {");
                 endMessage.append("\"total\":\"0\"");
                 endMessage.append(",");
                 endMessage.append("\"successCount\":\"0\"");
@@ -547,7 +547,7 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<Void>, S
                     }
                 }
 
-                logBatchEnd(total, successes, totalElapsedTime, totalBytes);
+                logDownloadEnd(total, successes, totalElapsedTime, totalBytes);
             }
 
             try {


### PR DESCRIPTION
to improve artifact-download performance.

Please refer to ticket 76736 in TinyPM.

Changed algorithm to keep all threads running until artifact-download finishes.