### PR TITLE
CADC-8575 CADC-9186 Updated artifact-discover and artifact-validate r…

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.5'
+version = '2.4.6'
 
 description = 'OpenCADC CAOM artifact sync library'
 def git_url = 'https://github.com/opencadc/caom2db'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactHarvester.java
@@ -129,7 +129,8 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<NullType>, S
     
     // reset each run
     long downloadCount = 0;
-    int processedCount = 0;
+    long updateCount = 0;
+    long processedCount = 0;
     Date start = new Date();
 
     public ArtifactHarvester(ObservationDAO observationDAO, HarvestResource harvestResource,
@@ -291,10 +292,13 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<NullType>, S
                                             this.downloadCount++;
                                             added = true;
                                             if (skip != null) {
+                                                this.downloadCount--;
                                                 if (this.errorMessage.equals(ArtifactHarvester.PROPRIETARY)) {
+                                                    this.updateCount++;
                                                     message = this.errorMessage 
-                                                        + " artifact already exists in skip table, update tryAfter date to relese date.";
+                                                        + " artifact already exists in skip table, update tryAfter date to release date.";
                                                 } else {
+                                                    added = false;
                                                     String msg = "artifact already exists in skip table.";;
                                                     if (this.reason.equalsIgnoreCase("None")) {
                                                         this.reason = "Public " + msg;
@@ -472,6 +476,8 @@ public class ArtifactHarvester implements PrivilegedExceptionAction<NullType>, S
         batchMessage.append("\"total\":\"").append(this.processedCount).append("\"");
         batchMessage.append(",");
         batchMessage.append("\"added\":\"").append(this.downloadCount).append("\"");
+        batchMessage.append(",");
+        batchMessage.append("\"updated\":\"").append(this.updateCount).append("\"");
         batchMessage.append(",");
         batchMessage.append("\"time\":\"").append(System.currentTimeMillis() - this.start.getTime()).append("\"");
         batchMessage.append(",");

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
@@ -82,7 +82,6 @@ import ca.nrc.cadc.date.DateUtil;
 import ca.nrc.cadc.io.ByteCountInputStream;
 import ca.nrc.cadc.net.HttpDownload;
 import ca.nrc.cadc.net.InputStreamWrapper;
-import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.profiler.Profiler;
 import ca.nrc.cadc.util.FileMetadata;
 

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
@@ -82,6 +82,7 @@ import ca.nrc.cadc.date.DateUtil;
 import ca.nrc.cadc.io.ByteCountInputStream;
 import ca.nrc.cadc.net.HttpDownload;
 import ca.nrc.cadc.net.InputStreamWrapper;
+import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.profiler.Profiler;
 import ca.nrc.cadc.util.FileMetadata;
 
@@ -360,7 +361,6 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
                 threadLog.debug("Starting download of " + artifactURI + " from " + url);
                 long start = System.currentTimeMillis();
                 download.run();
-                threadLog.debug("Completed download of " + artifactURI + " from " + url);
                 result.elapsedTimeMillis = System.currentTimeMillis() - start;
 
                 respCode = download.getResponseCode();
@@ -375,6 +375,7 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
                     result.message = sb.toString();
                 } else {
                     if (uploadSuccess) {
+                        threadLog.debug("Completed download of " + artifactURI + " from " + url);
                         result.success = true;
                     } else {
                         if (md5sumMessage == null) {
@@ -436,6 +437,7 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
             } catch (Throwable t) {
                 uploadSuccess = false;
                 uploadErrorMessage = "Upload error: " + t.getMessage();
+                throw new IOException(t);
             } finally {
                 bytesTransferred = byteCounter.getByteCount();
             }

--- a/caom2-persist/build.gradle
+++ b/caom2-persist/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.2'
+version = '2.4.3'
 
 description = 'OpenCADC CAOM persistence API library'
 def git_url = 'https://github.com/opencadc/caom2db'

--- a/caom2-persist/build.gradle
+++ b/caom2-persist/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 


### PR DESCRIPTION
…eporting.

Since we now update the harvestskipuri table, we should differentiate between adding and updating the harvestskipuri table. 

Example artifact-discover output:
2021-05-25 14:52:52.228 [Thread-1] INFO  ArtifactHarvester  - ENDDISCOVER: {"total":"120","added":"0","updated":"0","time":"38751","date":"2021-05-25 21:52:13.477"}

Example artifact-validate summary outputs:{"logType":"summary","collection":"IRIS","totalInCAOM":"2580","totalInStorage":"42","totalCorrect":"42","totalDiffChecksum":"0","totalDiffLength":"0","totalDiffType":"0","totalNotInCAOM":"0","totalMissingFromStorage":"2538","totalNotPublic":"0","totalAlreadyInSkipURI":"0","totalNewSkipURI":"0","totalUpdateSkipURI":"2538","time":"30572"}
{"logType":"summary","collection":"IRIS","totalInCAOM":"2580","totalInStorage":"42","totalCorrect":"42","totalDiffChecksum":"0","totalDiffLength":"0","totalDiffType":"0","totalNotInCAOM":"0","totalMissingFromStorage":"2538","totalNotPublic":"0","totalAlreadyInSkipURI":"0","totalNewSkipURI":"2538","totalUpdateSkipURI":"0","time":"30124"}