### PR TITLE
CSD-1567 Replaced deprecated HttpDownload with HttpGet and added time…

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.10'
+version = '2.4.11'
 
 description = 'OpenCADC CAOM artifact sync library'
 def git_url = 'https://github.com/opencadc/caom2db'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -85,7 +85,7 @@ import ca.nrc.cadc.caom2.harvester.state.HarvestSkipURI;
 import ca.nrc.cadc.caom2.harvester.state.HarvestSkipURIDAO;
 import ca.nrc.cadc.caom2.persistence.ObservationDAO;
 import ca.nrc.cadc.date.DateUtil;
-import ca.nrc.cadc.net.HttpDownload;
+import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.util.StringUtil;
 
@@ -613,8 +613,11 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
         queryString.append(URLEncoder.encode(adql, "UTF-8"));
         URL url = new URL(baseURL.toString() + "?" + queryString.toString());
         ResultReader resultReader = new ResultReader(artifactStore);
-        HttpDownload get = new HttpDownload(url, resultReader);
+        HttpGet get = new HttpGet(url, resultReader);
+        get.setConnectionTimeout(60000);
+        get.setReadTimeout(60000);
         try {
+            get.prepare();
             get.run();
         } catch (Throwable t) {
             t.printStackTrace();

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -617,7 +617,6 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
         get.setConnectionTimeout(60000);
         get.setReadTimeout(60000);
         try {
-            get.prepare();
             get.run();
         } catch (Throwable t) {
             t.printStackTrace();

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
@@ -80,7 +80,7 @@ import ca.nrc.cadc.caom2.harvester.state.HarvestSkipURIDAO;
 import ca.nrc.cadc.caom2.persistence.ArtifactDAO;
 import ca.nrc.cadc.date.DateUtil;
 import ca.nrc.cadc.io.ByteCountInputStream;
-import ca.nrc.cadc.net.HttpDownload;
+import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.InputStreamWrapper;
 import ca.nrc.cadc.profiler.Profiler;
 import ca.nrc.cadc.util.FileMetadata;
@@ -302,8 +302,11 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
                 URL url = caomArtifactResolver.getURL(artifactURI);
 
                 OutputStream out = new ByteArrayOutputStream();
-                HttpDownload head = new HttpDownload(url, out);
+                HttpGet head = new HttpGet(url, out);
+                head.setConnectionTimeout(60000);
+                head.setReadTimeout(60000);
                 head.setHeadOnly(true);
+                head.prepare();
                 head.run();
                 int respCode = head.getResponseCode();
                 profiler.checkpoint("remote.httpHead");
@@ -363,7 +366,10 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
                 }
                 profiler.checkpoint("local.httpHead");
 
-                HttpDownload download = new HttpDownload(url, this);
+                HttpGet download = new HttpGet(url, this);
+                download.setConnectionTimeout(60000);
+                download.setReadTimeout(60000);
+                download.prepare();
 
                 threadLog.debug("Starting download of " + artifactURI + " from " + url);
                 long start = System.currentTimeMillis();

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
@@ -306,7 +306,6 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
                 head.setConnectionTimeout(60000);
                 head.setReadTimeout(60000);
                 head.setHeadOnly(true);
-                head.prepare();
                 head.run();
                 int respCode = head.getResponseCode();
                 profiler.checkpoint("remote.httpHead");
@@ -369,7 +368,6 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
                 HttpGet download = new HttpGet(url, this);
                 download.setConnectionTimeout(60000);
                 download.setReadTimeout(60000);
-                download.prepare();
 
                 threadLog.debug("Starting download of " + artifactURI + " from " + url);
                 long start = System.currentTimeMillis();

--- a/caom2-repo-server/build.gradle
+++ b/caom2-repo-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.12'
+version = '2.4.13'
 
 description = 'OpenCADC CAOM repository server library'
 def git_url = 'https://github.com/opencadc/caom2db'

--- a/caom2-repo-server/src/test/java/ca/nrc/cadc/caom2/repo/action/RepoActionTest.java
+++ b/caom2-repo-server/src/test/java/ca/nrc/cadc/caom2/repo/action/RepoActionTest.java
@@ -74,9 +74,12 @@ import ca.nrc.cadc.caom2.repo.TestSyncOutput;
 import ca.nrc.cadc.log.WebServiceLogInfo;
 import ca.nrc.cadc.net.ResourceAlreadyExistsException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
+import ca.nrc.cadc.rest.RestServlet;
 import ca.nrc.cadc.util.Log4jInit;
 
 import java.security.AccessControlException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -193,6 +196,9 @@ public class RepoActionTest {
             super();
             this.ex = ex;
             setLogInfo(new TestLogInfo());
+            Map<String, String> initParams = new HashMap<String, String>();
+            initParams.put("authHeaders", "false");
+            setInitParams(initParams);
         }
 
         @Override


### PR DESCRIPTION
…outs to avoid HttpGet being 'hung'.

Asked Ling to try out artifact-diff-si and artifact-download-si on sciproc2-01 using HST collection. artifact-diff-si completed without being 'hung' and artifact-download-si uploaded more than 250 files to storage inventory without being 'hung' as well.