### PR TITLE
CSD-1567 Storage-inventory timeout issue. Changed timeout from 60s to 10 min.

### DIFF
--- a/caom2-artifact-sync/build.gradle
+++ b/caom2-artifact-sync/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '2.4.12'
+version = '2.4.13'
 
 description = 'OpenCADC CAOM artifact sync library'
 def git_url = 'https://github.com/opencadc/caom2db'

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/ArtifactValidator.java
@@ -614,8 +614,8 @@ public class ArtifactValidator implements PrivilegedExceptionAction<Object>, Shu
         URL url = new URL(baseURL.toString() + "?" + queryString.toString());
         ResultReader resultReader = new ResultReader(artifactStore);
         HttpGet get = new HttpGet(url, resultReader);
-        get.setConnectionTimeout(60000);
-        get.setReadTimeout(60000);
+        get.setConnectionTimeout(Caom2ArtifactSync.DEFAULT_TIMEOUT);
+        get.setReadTimeout(Caom2ArtifactSync.DEFAULT_TIMEOUT);
         try {
             get.run();
         } catch (Throwable t) {

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2ArtifactSync.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/Caom2ArtifactSync.java
@@ -100,6 +100,7 @@ public abstract class Caom2ArtifactSync {
 
     private static Logger log = Logger.getLogger(Caom2ArtifactSync.class);
     public static String DEFAULT_APPLICATION_NAME = "caom2-artifact-sync";
+    public static final int DEFAULT_TIMEOUT = 600000;  // 10 minutes
 
     private String asClassName;
     private Exception asException;

--- a/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
+++ b/caom2-artifact-sync/src/main/java/ca/nrc/cadc/caom2/artifactsync/DownloadArtifactFiles.java
@@ -303,8 +303,8 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
 
                 OutputStream out = new ByteArrayOutputStream();
                 HttpGet head = new HttpGet(url, out);
-                head.setConnectionTimeout(60000);
-                head.setReadTimeout(60000);
+                head.setConnectionTimeout(Caom2ArtifactSync.DEFAULT_TIMEOUT);
+                head.setReadTimeout(Caom2ArtifactSync.DEFAULT_TIMEOUT);
                 head.setHeadOnly(true);
                 head.run();
                 int respCode = head.getResponseCode();
@@ -366,8 +366,8 @@ public class DownloadArtifactFiles implements PrivilegedExceptionAction<NullType
                 profiler.checkpoint("local.httpHead");
 
                 HttpGet download = new HttpGet(url, this);
-                download.setConnectionTimeout(60000);
-                download.setReadTimeout(60000);
+                download.setConnectionTimeout(Caom2ArtifactSync.DEFAULT_TIMEOUT);
+                download.setReadTimeout(Caom2ArtifactSync.DEFAULT_TIMEOUT);
 
                 threadLog.debug("Starting download of " + artifactURI + " from " + url);
                 long start = System.currentTimeMillis();


### PR DESCRIPTION
Should have named the branch something like csd-1567a instead of "timeout".

ArtifactValidator failed to obtain a list of artifacts from storage-inventory. ArtifactValidator timed out before storage-inventory returned successfully. Here's an excerpt from John's findings.

"From the point of view of haproxy, the client terminated the connection (after about 60s in each case) before the backend server returned any results.  From the point of view of global.luskan, each query executed successfully and returned results after around 120s."

Successfully tested ArtifactValidator with a 10 minute timeout value. We want the timeout value to be user configurable. For now, a default timeout value is used. Since we want a fix to be released now, the configurable timeout feature will be postponed.