### PR TITLE
caom2-repo: clarify/generalise use of capabilities in RepoClient init

### DIFF
--- a/caom2-repo/build.gradle
+++ b/caom2-repo/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.4.2'
+version = '1.4.3'
 
 description = 'OpenCADC CAOM repository client library'
 def git_url = 'https://github.com/opencadc/caom2db'

--- a/caom2-repo/src/intTest/java/ca/nrc/cadc/caom2/repo/client/RepoClientTest.java
+++ b/caom2-repo/src/intTest/java/ca/nrc/cadc/caom2/repo/client/RepoClientTest.java
@@ -93,7 +93,7 @@ public class RepoClientTest {
     private static final Logger log = Logger.getLogger(RepoClientTest.class);
 
     static {
-        Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client.RepoClient", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.caom2.repo.client", Level.DEBUG);
         // Log4jInit.setLevel("ca.nrc.cadc.reg", Level.DEBUG);
     }
 
@@ -108,28 +108,17 @@ public class RepoClientTest {
     }
 
     @Test
-    public void testGetObservationList() {
+    public void testGetObservationListCADC() {
         try {
             Subject s = AuthenticationUtil.getSubject(new NetrcAuthenticator(true));
             Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
+                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/ams"), 8);
 
                     List<ObservationState> list = repoC.getObservationList("IRIS", null, null, 5);
-                    Assert.assertEquals(list.size(), 6);
-                    // Assert.assertEquals(URI.create("caom:IRIS/f001h000"),
-                    // list.get(0).getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f002h000"),
-                    // list.get(1).getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f003h000"),
-                    // list.get(2).getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f004h000"),
-                    // list.get(3).getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f005h000"),
-                    // list.get(4).getURI().getURI());
-
+                    Assert.assertEquals(6, list.size());
                     return null;
                 }
             });
@@ -140,7 +129,7 @@ public class RepoClientTest {
     }
 
     @Test
-    public void testGetObservationListStsci() {
+    public void testGetObservationListMAST() {
         try {
             Subject s = AuthenticationUtil.getAnonSubject();
             Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
@@ -150,7 +139,7 @@ public class RepoClientTest {
                     RepoClient repoC = new RepoClient(URI.create("ivo://mast.stsci.edu/caom2repo"), 8);
 
                     List<ObservationState> list = repoC.getObservationList("HST", null, null, 5);
-                    Assert.assertEquals(list.size(), 6);
+                    Assert.assertEquals(6, list.size());
 
                     return null;
                 }
@@ -169,9 +158,9 @@ public class RepoClientTest {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
+                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/ams"), 8);
 
-                    List<ObservationState> list = repoC.getObservationList("IRIS", null, null, 5);
+                    List<ObservationState> list = repoC.getObservationList("DAO", null, null, 5);
                     Assert.fail("expected exception, got results");
 
                     return null;
@@ -186,38 +175,6 @@ public class RepoClientTest {
     }
 
     @Test
-    public void testGetList() {
-        try {
-            Subject s = AuthenticationUtil.getSubject(new NetrcAuthenticator(true));
-            Subject.doAs(s, new PrivilegedExceptionAction<Object>() {
-
-                @Override
-                public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
-
-                    List<ObservationResponse> list = repoC.getList("IRIS", null, null, 5);
-                    Assert.assertEquals(list.size(), 6);
-                    // Assert.assertEquals(URI.create("caom:IRIS/f001h000"),
-                    // list.get(0).getObservation().getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f002h000"),
-                    // list.get(1).getObservation().getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f003h000"),
-                    // list.get(2).getObservation().getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f004h000"),
-                    // list.get(3).getObservation().getURI().getURI());
-                    // Assert.assertEquals(URI.create("caom:IRIS/f005h000"),
-                    // list.get(4).getObservation().getURI().getURI());
-
-                    return null;
-                }
-            });
-        } catch (Exception unexpected) {
-            log.error("unexpected exception", unexpected);
-            Assert.fail("unexpected exception: " + unexpected);
-        }
-    }
-
-    @Test
     public void testGet() {
         try {
             Subject s = AuthenticationUtil.getSubject(new NetrcAuthenticator(true));
@@ -225,11 +182,12 @@ public class RepoClientTest {
 
                 @Override
                 public Object run() throws Exception {
-                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/caom2repo"), 8);
+                    RepoClient repoC = new RepoClient(URI.create("ivo://cadc.nrc.ca/ams"), 8);
 
                     ObservationResponse wr = repoC.get(new ObservationURI("IRIS", "f001h000"));
+                    Assert.assertNotNull(wr);
                     Assert.assertNotNull(wr.observation);
-                    Assert.assertEquals(wr.observation.getID().toString(), "00000000-0000-0000-897c-013ac26a8f32");
+                    Assert.assertFalse(wr.observation.getPlanes().isEmpty());
 
                     return null;
                 }

--- a/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/Worker.java
+++ b/caom2-repo/src/main/java/ca/nrc/cadc/caom2/repo/client/Worker.java
@@ -135,7 +135,11 @@ public class Worker implements Callable<ObservationResponse> {
 
         ObservationResponse wr = new ObservationResponse(state);
         if (get.getThrowable() != null) {
-            wr.error = new RuntimeException("failed to get observation", get.getThrowable());
+            if (get.getThrowable() instanceof Exception) {
+                wr.error = (Exception) get.getThrowable();
+            } else {
+                wr.error = new RuntimeException("failed to get observation", get.getThrowable());
+            }
         } else {
             try {
                 ObservationReader obsReader = new ObservationReader();


### PR DESCRIPTION
simplify Worker error handling tom avoid unnecessary wrap in RuntimeException
fix up integration tests